### PR TITLE
Add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",
+    "homepage": "https://developer.todoist.com/rest/v1/?javascript",
     "license": "MIT",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Have it pointing to the API documentation instead of the GH repo.