### PR TITLE
ci: Remove reference to unused secret.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,6 @@ jobs:
 
             - name: Configure doist package repository
               uses: actions/setup-node@v1
-              with:
-                  scope: '@doist'
-                  registry-url: 'https://npm.pkg.github.com'
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,6 @@ jobs:
 
             - name: Install dependencies
               run: npm ci
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
             - name: Run CI Check
               run: npm run integrity-checks


### PR DESCRIPTION
I’ve noticed `CI.yml` workflow file referencing `secrets.GH_PACKAGES_TOKEN`, which should not be used in this public repository.

After having removed the reference, GitHub package registry was still being used, which I tracked down to wrong setup in `setup-node` action. 