### PR TITLE
build: set sensible timout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
     ci:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 31
         steps:
             - name: Git checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
Based on historical data, clamped between 5 and 60.

See https://github.com/Doist/Issues/issues/5259