### PR TITLE
refactor: Remove jest-mock-extended, fix test.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
                 "eslint-plugin-prettier": "^3.4.0",
                 "husky": "^7.0.4",
                 "jest": "^27.3.1",
-                "jest-mock-extended": "^1.0.14",
                 "lint-staged": "^12.3.3",
                 "npm-run-all": "^4.1.5",
                 "prettier": "^2.2.1",
@@ -4759,19 +4758,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-mock-extended": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-1.0.14.tgz",
-            "integrity": "sha512-qZx93sSita+c9Qes7+FDCUN6yN9dGJa9gULN5oql5N9phThm5/4wYoxQgCDB6PXyDb07NuaTsAplk3T0nCl5tg==",
-            "dev": true,
-            "dependencies": {
-                "ts-essentials": "^4.0.0"
-            },
-            "peerDependencies": {
-                "jest": "^24.0.0 || ^25.0.0 || ^26.0.0",
-                "typescript": "^3.0.0 || ^4.0.0"
-            }
-        },
         "node_modules/jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -7292,12 +7278,6 @@
             "engines": {
                 "node": ">=8.0.0"
             }
-        },
-        "node_modules/ts-essentials": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-4.0.0.tgz",
-            "integrity": "sha512-uQJX+SRY9mtbKU+g9kl5Fi7AEMofPCvHfJkQlaygpPmHPZrtgaBqbWFOYyiA47RhnSwwnXdepUJrgqUYxoUyhQ==",
-            "dev": true
         },
         "node_modules/ts-jest": {
             "version": "27.0.7",
@@ -11591,15 +11571,6 @@
                 "@types/node": "*"
             }
         },
-        "jest-mock-extended": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-1.0.14.tgz",
-            "integrity": "sha512-qZx93sSita+c9Qes7+FDCUN6yN9dGJa9gULN5oql5N9phThm5/4wYoxQgCDB6PXyDb07NuaTsAplk3T0nCl5tg==",
-            "dev": true,
-            "requires": {
-                "ts-essentials": "^4.0.0"
-            }
-        },
         "jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -13535,12 +13506,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.0.tgz",
             "integrity": "sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A=="
-        },
-        "ts-essentials": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-4.0.0.tgz",
-            "integrity": "sha512-uQJX+SRY9mtbKU+g9kl5Fi7AEMofPCvHfJkQlaygpPmHPZrtgaBqbWFOYyiA47RhnSwwnXdepUJrgqUYxoUyhQ==",
-            "dev": true
         },
         "ts-jest": {
             "version": "27.0.7",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "eslint-plugin-prettier": "^3.4.0",
         "husky": "^7.0.4",
         "jest": "^27.3.1",
-        "jest-mock-extended": "^1.0.14",
         "lint-staged": "^12.3.3",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.2.1",

--- a/src/restClient.test.ts
+++ b/src/restClient.test.ts
@@ -1,6 +1,5 @@
 import Axios, { AxiosStatic, AxiosResponse, AxiosError } from 'axios'
 import { request, isSuccess } from './restClient'
-import { mock } from 'jest-mock-extended'
 import { TodoistRequestError } from './types/errors'
 import * as caseConverter from 'axios-case-converter'
 import { assertInstance } from './testUtils/asserts'
@@ -33,9 +32,9 @@ const DEFAULT_PAYLOAD = {
     someKey: 'someValue',
 }
 
-const DEFAULT_RESPONSE = mock<AxiosResponse>({
+const DEFAULT_RESPONSE = {
     data: DEFAULT_PAYLOAD,
-})
+} as AxiosResponse
 
 const DEFAULT_ERROR_MESSAGE = 'There was an error'
 
@@ -55,10 +54,11 @@ function setupAxiosMockWithError(statusCode: number, responseData: unknown) {
     const axiosMock = Axios as jest.Mocked<typeof Axios>
     axiosMock.create = jest.fn(() => axiosMock)
 
-    const axiosError = mock<AxiosError>({
+    const axiosError = {
         message: DEFAULT_ERROR_MESSAGE,
-        response: { status: statusCode, data: responseData },
-    })
+        response: { status: statusCode, data: responseData } as AxiosResponse,
+        isAxiosError: true,
+    } as AxiosError
 
     function errorFunc(): Promise<unknown> {
         throw axiosError
@@ -215,7 +215,7 @@ describe('restClient', () => {
     ] as const
 
     test.each(responseStatusTheories)('status code %p returns isSuccess %p', (status, expected) => {
-        const response = mock<AxiosResponse>({ status })
+        const response = { status } as AxiosResponse
         const success = isSuccess(response)
         expect(success).toEqual(expected)
     })

--- a/src/testUtils/mocks.ts
+++ b/src/testUtils/mocks.ts
@@ -1,8 +1,7 @@
-import { mock } from 'jest-mock-extended'
 import { AxiosResponse } from 'axios'
 import * as restClient from '../restClient'
 
 export function setupRestClientMock(responseData: unknown, status = 200): jest.SpyInstance {
-    const response = mock<AxiosResponse>({ status, data: responseData })
+    const response = { status, data: responseData } as AxiosResponse
     return jest.spyOn(restClient, 'request').mockResolvedValue(response)
 }


### PR DESCRIPTION
I don't quite understand the reason for using `jest-mock-extended` package, but the way we are currently using it is definitely wrong. In particular, `isAxiosError` implementation performs a `Boolean(...)` conversion. `Boolean(Function)` is `true`, so it is incorrectly depended upon that `isAxiosError(mock<AxiosError>().isAxiosError) === true`, while `isAxiosError ` is really undefined.

I propose that we remove `jest-mock-extended` package until we really need it, and simply use type casted placeholder objects instead.