### PR TITLE
refactor: Remove `url-join` dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "axios-retry": "^3.1.9",
                 "runtypes": "^6.5.0",
                 "ts-custom-error": "^3.2.0",
-                "url-join": "^4.0.1",
                 "uuid": "^8.3.1"
             },
             "devDependencies": {
@@ -22,7 +21,6 @@
                 "@doist/prettier-config": "3.0.5",
                 "@types/axios": "0.14.0",
                 "@types/jest": "27.4.1",
-                "@types/url-join": "4.0.1",
                 "@types/uuid": "8.3.4",
                 "@typescript-eslint/eslint-plugin": "5.19.0",
                 "@typescript-eslint/parser": "5.19.0",
@@ -1308,12 +1306,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-            "dev": true
-        },
-        "node_modules/@types/url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
             "dev": true
         },
         "node_modules/@types/uuid": {
@@ -7646,11 +7638,6 @@
                 "punycode": "^2.1.0"
             }
         },
-        "node_modules/url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-        },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -9095,12 +9082,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-            "dev": true
-        },
-        "@types/url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
             "dev": true
         },
         "@types/uuid": {
@@ -13876,11 +13857,6 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
-        },
-        "url-join": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
         },
         "uuid": {
             "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "axios-retry": "^3.1.9",
         "runtypes": "^6.5.0",
         "ts-custom-error": "^3.2.0",
-        "url-join": "^4.0.1",
         "uuid": "^8.3.1"
     },
     "devDependencies": {
@@ -37,7 +36,6 @@
         "@doist/prettier-config": "3.0.5",
         "@types/axios": "0.14.0",
         "@types/jest": "27.4.1",
-        "@types/url-join": "4.0.1",
         "@types/uuid": "8.3.4",
         "@typescript-eslint/eslint-plugin": "5.19.0",
         "@typescript-eslint/parser": "5.19.0",

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -54,6 +54,11 @@ import {
     validateUserArray,
 } from './utils/validators'
 
+/**
+ * Joins path segments using `/` separator.
+ * @param segments A list of **valid** path segments.
+ * @returns A joined path.
+ */
 function generatePath(...segments: string[]): string {
     return segments.join('/')
 }

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -27,7 +27,6 @@ import {
 } from './types/requests'
 import { request, isSuccess } from './restClient'
 import { getTaskFromQuickAddResponse } from './utils/taskConverters'
-import urljoin from 'url-join'
 import {
     API_REST_BASE_URI,
     API_SYNC_BASE_URI,
@@ -55,6 +54,10 @@ import {
     validateUserArray,
 } from './utils/validators'
 
+function generatePath(...segments: string[]): string {
+    return segments.join('/')
+}
+
 export class TodoistApi {
     authToken: string
 
@@ -67,7 +70,7 @@ export class TodoistApi {
         const response = await request<Task>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
         )
 
@@ -118,7 +121,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
             args,
             requestId,
@@ -131,7 +134,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_CLOSE),
+            generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_CLOSE),
             this.authToken,
             undefined,
             requestId,
@@ -144,7 +147,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_REOPEN),
+            generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_REOPEN),
             this.authToken,
             undefined,
             requestId,
@@ -157,7 +160,7 @@ export class TodoistApi {
         const response = await request(
             'DELETE',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
             undefined,
             requestId,
@@ -170,7 +173,7 @@ export class TodoistApi {
         const response = await request<Project>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
         )
 
@@ -206,7 +209,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
             args,
             requestId,
@@ -219,7 +222,7 @@ export class TodoistApi {
         const response = await request(
             'DELETE',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
             requestId,
         )
@@ -231,7 +234,11 @@ export class TodoistApi {
         const response = await request<User[]>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_PROJECTS, String(projectId), ENDPOINT_REST_PROJECT_COLLABORATORS),
+            generatePath(
+                ENDPOINT_REST_PROJECTS,
+                String(projectId),
+                ENDPOINT_REST_PROJECT_COLLABORATORS,
+            ),
             this.authToken,
         )
 
@@ -255,7 +262,7 @@ export class TodoistApi {
         const response = await request<Section>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
         )
 
@@ -280,7 +287,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
             args,
             requestId,
@@ -293,7 +300,7 @@ export class TodoistApi {
         const response = await request(
             'DELETE',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
             undefined,
             requestId,
@@ -306,7 +313,7 @@ export class TodoistApi {
         const response = await request<Label>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
         )
 
@@ -342,7 +349,7 @@ export class TodoistApi {
         const response = await request(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
             args,
             requestId,
@@ -355,7 +362,7 @@ export class TodoistApi {
         const response = await request(
             'DELETE',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
             undefined,
             requestId,
@@ -380,7 +387,7 @@ export class TodoistApi {
         const response = await request<Comment>(
             'GET',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
         )
 
@@ -408,7 +415,7 @@ export class TodoistApi {
         const response = await request<boolean>(
             'POST',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
             args,
             requestId,
@@ -421,7 +428,7 @@ export class TodoistApi {
         const response = await request(
             'DELETE',
             API_REST_BASE_URI,
-            urljoin(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
             undefined,
             requestId,


### PR DESCRIPTION
Continued from https://github.com/Doist/todoist-api-typescript/pull/60. Completely remove `url-join` dependency.

Please note that `url-join` was used incorrectly - it expected the first argument to be baseURL, not partial path. Other than that, we are now doing [the same thing](https://github.com/jfromaniello/url-join/blob/88bad0fa91216e9b199cb3962009d67ae681d6fb/lib/url-join.js#L47) it did, minus unnecessary processing we don't need.

`TodoistApi.*.test` tests are pretty comprehensive, so this should be safe.