### PR TITLE
chore: Adds support for accessing Todoist via a baseUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/TodoistApi.comments.test.ts
+++ b/src/TodoistApi.comments.test.ts
@@ -5,7 +5,7 @@ import {
     DEFAULT_REQUEST_ID,
     INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
-import { API_REST_BASE_URI, ENDPOINT_REST_COMMENTS } from './consts/endpoints'
+import { getRestBaseUri, ENDPOINT_REST_COMMENTS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 import { assertInputValidationError } from './testUtils/asserts'
 
@@ -25,7 +25,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_COMMENTS,
                 DEFAULT_AUTH_TOKEN,
                 getCommentsArgs,
@@ -54,7 +54,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${commentId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -92,7 +92,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_COMMENTS,
                 DEFAULT_AUTH_TOKEN,
                 addCommentArgs,
@@ -126,7 +126,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateCommentArgs,
@@ -161,7 +161,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.labels.test.ts
+++ b/src/TodoistApi.labels.test.ts
@@ -5,7 +5,7 @@ import {
     DEFAULT_REQUEST_ID,
     INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
-import { API_REST_BASE_URI, ENDPOINT_REST_LABELS } from './consts/endpoints'
+import { getRestBaseUri, ENDPOINT_REST_LABELS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 import { assertInputValidationError } from './testUtils/asserts'
 
@@ -25,7 +25,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -57,7 +57,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_LABELS,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -88,7 +88,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_LABELS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_LABEL_ARGS,
@@ -121,7 +121,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_UPDATE_LABEL_ARGS,
@@ -157,7 +157,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -7,7 +7,7 @@ import {
     INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
 import {
-    API_REST_BASE_URI,
+    getRestBaseUri,
     ENDPOINT_REST_PROJECTS,
     ENDPOINT_REST_PROJECT_COLLABORATORS,
 } from './consts/endpoints'
@@ -30,7 +30,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -62,7 +62,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_PROJECTS,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -93,7 +93,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_PROJECTS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_PROJECT_ARGS,
@@ -123,7 +123,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateArgs,
@@ -158,7 +158,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_REQUEST_ID,
@@ -194,7 +194,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}/${ENDPOINT_REST_PROJECT_COLLABORATORS}`,
                 DEFAULT_AUTH_TOKEN,
             )

--- a/src/TodoistApi.sections.test.ts
+++ b/src/TodoistApi.sections.test.ts
@@ -5,7 +5,7 @@ import {
     DEFAULT_SECTION,
     INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
-import { API_REST_BASE_URI, ENDPOINT_REST_SECTIONS } from './consts/endpoints'
+import { getRestBaseUri, ENDPOINT_REST_SECTIONS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 import { assertInputValidationError } from './testUtils/asserts'
 
@@ -25,7 +25,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -58,7 +58,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_SECTIONS,
                 DEFAULT_AUTH_TOKEN,
                 { projectId },
@@ -91,7 +91,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_SECTIONS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_SECTION_ARGS,
@@ -121,7 +121,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateArgs,
@@ -157,7 +157,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.tasks.test.ts
+++ b/src/TodoistApi.tasks.test.ts
@@ -9,8 +9,8 @@ import {
     INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
 import {
-    API_REST_BASE_URI,
-    API_SYNC_BASE_URI,
+    getRestBaseUri,
+    getSyncBaseUri,
     ENDPOINT_REST_TASK_CLOSE,
     ENDPOINT_REST_TASK_REOPEN,
     ENDPOINT_REST_TASKS,
@@ -23,8 +23,8 @@ function setupSyncTaskConverter(returnedTask: Task) {
     return jest.spyOn(taskConverters, 'getTaskFromQuickAddResponse').mockReturnValue(returnedTask)
 }
 
-function getTarget() {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN)
+function getTarget(baseUrl = 'https://api.todoist.com') {
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
 }
 
 describe('TodoistApi task endpoints', () => {
@@ -42,7 +42,24 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
+                ENDPOINT_REST_TASKS,
+                DEFAULT_AUTH_TOKEN,
+                DEFAULT_ADD_TASK_ARGS,
+                DEFAULT_REQUEST_ID,
+            )
+        })
+
+        test('calls post on restClient with expected parameters against staging', async () => {
+            const requestMock = setupRestClientMock(DEFAULT_TASK)
+            const api = getTarget('https://staging.todoist.com')
+
+            await api.addTask(DEFAULT_ADD_TASK_ARGS, DEFAULT_REQUEST_ID)
+
+            expect(requestMock).toBeCalledTimes(1)
+            expect(requestMock).toBeCalledWith(
+                'POST',
+                getRestBaseUri('https://staging.todoist.com'),
                 ENDPOINT_REST_TASKS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_TASK_ARGS,
@@ -72,7 +89,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateArgs,
@@ -108,7 +125,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}/${ENDPOINT_REST_TASK_CLOSE}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -143,7 +160,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}/${ENDPOINT_REST_TASK_REOPEN}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -178,7 +195,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -219,7 +236,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                API_SYNC_BASE_URI,
+                getSyncBaseUri(),
                 ENDPOINT_SYNC_QUICK_ADD,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_QUICK_ADD_ARGS,
@@ -250,7 +267,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -277,7 +294,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                API_REST_BASE_URI,
+                getRestBaseUri(),
                 ENDPOINT_REST_TASKS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_GET_TASKS_ARGS,

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -28,8 +28,8 @@ import {
 import { request, isSuccess } from './restClient'
 import { getTaskFromQuickAddResponse } from './utils/taskConverters'
 import {
-    API_REST_BASE_URI,
-    API_SYNC_BASE_URI,
+    getRestBaseUri,
+    getSyncBaseUri,
     ENDPOINT_REST_TASKS,
     ENDPOINT_REST_PROJECTS,
     ENDPOINT_SYNC_QUICK_ADD,
@@ -66,15 +66,21 @@ function generatePath(...segments: string[]): string {
 export class TodoistApi {
     authToken: string
 
-    constructor(authToken: string) {
+    constructor(authToken: string, baseUrl?: string) {
         this.authToken = authToken
+
+        this.restApiBase = getRestBaseUri(baseUrl)
+        this.syncApiBase = getSyncBaseUri(baseUrl)
     }
+
+    private restApiBase: string
+    private syncApiBase: string
 
     async getTask(id: number): Promise<Task> {
         Int.check(id)
         const response = await request<Task>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
         )
@@ -85,7 +91,7 @@ export class TodoistApi {
     async getTasks(args?: GetTasksArgs): Promise<Task[]> {
         const response = await request<Task[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_TASKS,
             this.authToken,
             args,
@@ -97,7 +103,7 @@ export class TodoistApi {
     async addTask(args: AddTaskArgs, requestId?: string): Promise<Task> {
         const response = await request<Task>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_TASKS,
             this.authToken,
             args,
@@ -110,7 +116,7 @@ export class TodoistApi {
     async quickAddTask(args: QuickAddTaskArgs): Promise<Task> {
         const response = await request<QuickAddTaskResponse>(
             'POST',
-            API_SYNC_BASE_URI,
+            this.syncApiBase,
             ENDPOINT_SYNC_QUICK_ADD,
             this.authToken,
             args,
@@ -125,7 +131,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
             args,
@@ -138,7 +144,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_CLOSE),
             this.authToken,
             undefined,
@@ -151,7 +157,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_REOPEN),
             this.authToken,
             undefined,
@@ -164,7 +170,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'DELETE',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_TASKS, String(id)),
             this.authToken,
             undefined,
@@ -177,7 +183,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request<Project>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
         )
@@ -188,7 +194,7 @@ export class TodoistApi {
     async getProjects(): Promise<Project[]> {
         const response = await request<Project[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_PROJECTS,
             this.authToken,
         )
@@ -199,7 +205,7 @@ export class TodoistApi {
     async addProject(args: AddProjectArgs, requestId?: string): Promise<Project> {
         const response = await request<Project>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_PROJECTS,
             this.authToken,
             args,
@@ -213,7 +219,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
             args,
@@ -226,7 +232,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'DELETE',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_PROJECTS, String(id)),
             this.authToken,
             requestId,
@@ -238,7 +244,7 @@ export class TodoistApi {
         Int.check(projectId)
         const response = await request<User[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(
                 ENDPOINT_REST_PROJECTS,
                 String(projectId),
@@ -253,7 +259,7 @@ export class TodoistApi {
     async getSections(projectId?: number): Promise<Section[]> {
         const response = await request<Section[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_SECTIONS,
             this.authToken,
             projectId && { projectId },
@@ -266,7 +272,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request<Section>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
         )
@@ -277,7 +283,7 @@ export class TodoistApi {
     async addSection(args: AddSectionArgs, requestId?: string): Promise<Section> {
         const response = await request<Section>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_SECTIONS,
             this.authToken,
             args,
@@ -291,7 +297,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
             args,
@@ -304,7 +310,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'DELETE',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_SECTIONS, String(id)),
             this.authToken,
             undefined,
@@ -317,7 +323,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request<Label>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
         )
@@ -328,7 +334,7 @@ export class TodoistApi {
     async getLabels(): Promise<Label[]> {
         const response = await request<Label[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_LABELS,
             this.authToken,
         )
@@ -339,7 +345,7 @@ export class TodoistApi {
     async addLabel(args: AddLabelArgs, requestId?: string): Promise<Label> {
         const response = await request<Label>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_LABELS,
             this.authToken,
             args,
@@ -353,7 +359,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
             args,
@@ -366,7 +372,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'DELETE',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_LABELS, String(id)),
             this.authToken,
             undefined,
@@ -378,7 +384,7 @@ export class TodoistApi {
     async getComments(args: GetTaskCommentsArgs | GetProjectCommentsArgs): Promise<Comment[]> {
         const response = await request<Comment[]>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_COMMENTS,
             this.authToken,
             args,
@@ -391,7 +397,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request<Comment>(
             'GET',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
         )
@@ -405,7 +411,7 @@ export class TodoistApi {
     ): Promise<Comment> {
         const response = await request<Comment>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             ENDPOINT_REST_COMMENTS,
             this.authToken,
             args,
@@ -419,7 +425,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request<boolean>(
             'POST',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
             args,
@@ -432,7 +438,7 @@ export class TodoistApi {
         Int.check(id)
         const response = await request(
             'DELETE',
-            API_REST_BASE_URI,
+            this.restApiBase,
             generatePath(ENDPOINT_REST_COMMENTS, String(id)),
             this.authToken,
             undefined,

--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -10,20 +10,36 @@ describe('authentication', () => {
                 'SomeId',
                 'SomeState',
                 ['data:read_write'] as Permission[],
+                undefined,
                 'https://todoist.com/oauth/authorize?client_id=SomeId&scope=data:read_write&state=SomeState',
             ],
             [
                 'SomeId',
                 'SomeState',
                 ['data:read', 'project:delete'] as Permission[],
+                undefined,
                 'https://todoist.com/oauth/authorize?client_id=SomeId&scope=data:read,project:delete&state=SomeState',
+            ],
+            [
+                'SomeId',
+                'SomeState',
+                ['data:read_write'] as Permission[],
+                'https://staging.todoist.com',
+                'https://staging.todoist.com/oauth/authorize?client_id=SomeId&scope=data:read_write&state=SomeState',
+            ],
+            [
+                'SomeId',
+                'SomeState',
+                ['data:read', 'project:delete'] as Permission[],
+                'https://staging.todoist.com',
+                'https://staging.todoist.com/oauth/authorize?client_id=SomeId&scope=data:read,project:delete&state=SomeState',
             ],
         ] as const
 
         test.each(authUrlTheories)(
             'Formatting %p with arguments %p returns %p',
-            (clientId, state, permissions, expected) => {
-                const url = getAuthorizationUrl(clientId, permissions, state)
+            (clientId, state, permissions, baseUrl, expected) => {
+                const url = getAuthorizationUrl(clientId, permissions, state, baseUrl)
                 expect(url).toEqual(expected)
             },
         )

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -2,8 +2,8 @@ import { request, isSuccess } from './restClient'
 import { v4 as uuid } from 'uuid'
 import { TodoistRequestError } from './types'
 import {
-    API_AUTHORIZATION_BASE_URI,
-    API_SYNC_BASE_URI,
+    getAuthBaseUri,
+    getSyncBaseUri,
     ENDPOINT_AUTHORIZATION,
     ENDPOINT_GET_TOKEN,
     ENDPOINT_REVOKE_TOKEN,
@@ -41,19 +41,25 @@ export function getAuthorizationUrl(
     clientId: string,
     permissions: Permission[],
     state: string,
+    baseUrl?: string,
 ): string {
     if (!permissions?.length) {
         throw new Error('At least one scope value should be passed for permissions.')
     }
 
     const scope = permissions.join(',')
-    return `${API_AUTHORIZATION_BASE_URI}${ENDPOINT_AUTHORIZATION}?client_id=${clientId}&scope=${scope}&state=${state}`
+    return `${getAuthBaseUri(
+        baseUrl,
+    )}${ENDPOINT_AUTHORIZATION}?client_id=${clientId}&scope=${scope}&state=${state}`
 }
 
-export async function getAuthToken(args: AuthTokenRequestArgs): Promise<AuthTokenResponse> {
+export async function getAuthToken(
+    args: AuthTokenRequestArgs,
+    baseUrl?: string,
+): Promise<AuthTokenResponse> {
     const response = await request<AuthTokenResponse>(
         'POST',
-        API_AUTHORIZATION_BASE_URI,
+        getAuthBaseUri(baseUrl),
         ENDPOINT_GET_TOKEN,
         undefined,
         args,
@@ -70,10 +76,13 @@ export async function getAuthToken(args: AuthTokenRequestArgs): Promise<AuthToke
     return response.data
 }
 
-export async function revokeAuthToken(args: RevokeAuthTokenRequestArgs): Promise<boolean> {
+export async function revokeAuthToken(
+    args: RevokeAuthTokenRequestArgs,
+    baseUrl?: string,
+): Promise<boolean> {
     const response = await request(
         'POST',
-        API_SYNC_BASE_URI,
+        getSyncBaseUri(baseUrl),
         ENDPOINT_REVOKE_TOKEN,
         undefined,
         args,

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -1,6 +1,20 @@
-export const API_REST_BASE_URI = 'https://api.todoist.com/rest/v1/'
-export const API_SYNC_BASE_URI = 'https://api.todoist.com/sync/v8/'
-export const API_AUTHORIZATION_BASE_URI = 'https://todoist.com/oauth/'
+const BASE_URI = 'https://api.todoist.com'
+const API_REST_BASE_URI = '/rest/v1/'
+const API_SYNC_BASE_URI = '/sync/v8/'
+const TODOIST_URI = 'https://todoist.com'
+const API_AUTHORIZATION_BASE_URI = '/oauth/'
+
+export function getRestBaseUri(domainBase: string = BASE_URI): string {
+    return new URL(API_REST_BASE_URI, domainBase).toString()
+}
+
+export function getSyncBaseUri(domainBase: string = BASE_URI): string {
+    return new URL(API_SYNC_BASE_URI, domainBase).toString()
+}
+
+export function getAuthBaseUri(domainBase: string = TODOIST_URI): string {
+    return new URL(API_AUTHORIZATION_BASE_URI, domainBase).toString()
+}
 
 export const ENDPOINT_REST_TASKS = 'tasks'
 export const ENDPOINT_REST_PROJECTS = 'projects'


### PR DESCRIPTION
This adds a new, optional, API surface that allows the consumer to dictate whether they want to access the staging APIs. By default, if not present, it will revert to the production API. Getting staging data is fully opt-in.