### PR TITLE
refactor: Accept nulls for optional entity fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 .npm
 .eslintcache
 scratch.ts
+
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/TodoistApi.comments.test.ts
+++ b/src/TodoistApi.comments.test.ts
@@ -1,13 +1,14 @@
 import { TodoistApi } from '.'
 import {
+    COMMENT_WITH_ATTACHMENT_WITH_OPTIONALS_AS_NULL,
+    COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT,
+    COMMENT_WITH_OPTIONALS_AS_NULL_TASK,
     DEFAULT_AUTH_TOKEN,
     DEFAULT_COMMENT,
     DEFAULT_REQUEST_ID,
-    INVALID_ENTITY_ID,
 } from './testUtils/testDefaults'
 import { getRestBaseUri, ENDPOINT_REST_COMMENTS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
-import { assertInputValidationError } from './testUtils/asserts'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
@@ -33,7 +34,12 @@ describe('TodoistApi comment endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            const expectedComments = [DEFAULT_COMMENT]
+            const expectedComments = [
+                DEFAULT_COMMENT,
+                COMMENT_WITH_OPTIONALS_AS_NULL_TASK,
+                COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT,
+                COMMENT_WITH_ATTACHMENT_WITH_OPTIONALS_AS_NULL,
+            ]
             setupRestClientMock(expectedComments)
             const api = getTarget()
 
@@ -45,7 +51,7 @@ describe('TodoistApi comment endpoints', () => {
 
     describe('getComment', () => {
         test('calls get on expected url', async () => {
-            const commentId = 1
+            const commentId = '1'
             const requestMock = setupRestClientMock(DEFAULT_COMMENT)
             const api = getTarget()
 
@@ -65,15 +71,9 @@ describe('TodoistApi comment endpoints', () => {
             setupRestClientMock(expectedComment)
             const api = getTarget()
 
-            const comment = await api.getComment(1)
+            const comment = await api.getComment('1')
 
             expect(comment).toEqual(expectedComment)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getComment(INVALID_ENTITY_ID),
-            )
         })
     })
 
@@ -117,7 +117,7 @@ describe('TodoistApi comment endpoints', () => {
         }
 
         test('makes post request with expected params', async () => {
-            const taskId = 1
+            const taskId = '1'
             const requestMock = setupRestClientMock(DEFAULT_COMMENT, 204)
             const api = getTarget()
 
@@ -139,21 +139,15 @@ describe('TodoistApi comment endpoints', () => {
             setupRestClientMock(returnedComment, 204)
             const api = getTarget()
 
-            const result = await api.updateComment(1, updateCommentArgs)
+            const result = await api.updateComment('1', updateCommentArgs)
 
             expect(result).toEqual(returnedComment)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().updateComment(INVALID_ENTITY_ID, updateCommentArgs),
-            )
         })
     })
 
     describe('deleteComment', () => {
         test('makes delete request on expected url', async () => {
-            const taskId = 1
+            const taskId = '1'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -174,15 +168,9 @@ describe('TodoistApi comment endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const result = await api.deleteComment(1)
+            const result = await api.deleteComment('1')
 
             expect(result).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().deleteComment(INVALID_ENTITY_ID),
-            )
         })
     })
 })

--- a/src/TodoistApi.labels.test.ts
+++ b/src/TodoistApi.labels.test.ts
@@ -1,13 +1,7 @@
 import { TodoistApi } from '.'
-import {
-    DEFAULT_AUTH_TOKEN,
-    DEFAULT_LABEL,
-    DEFAULT_REQUEST_ID,
-    INVALID_ENTITY_ID,
-} from './testUtils/testDefaults'
+import { DEFAULT_AUTH_TOKEN, DEFAULT_LABEL, DEFAULT_REQUEST_ID } from './testUtils/testDefaults'
 import { getRestBaseUri, ENDPOINT_REST_LABELS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
-import { assertInputValidationError } from './testUtils/asserts'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
@@ -16,7 +10,7 @@ function getTarget() {
 describe('TodoistApi label endpoints', () => {
     describe('getLabel', () => {
         test('calls get request with expected url', async () => {
-            const labelId = 12
+            const labelId = '12'
             const requestMock = setupRestClientMock(DEFAULT_LABEL)
             const api = getTarget()
 
@@ -35,15 +29,9 @@ describe('TodoistApi label endpoints', () => {
             setupRestClientMock(DEFAULT_LABEL)
             const api = getTarget()
 
-            const label = await api.getLabel(123)
+            const label = await api.getLabel('123')
 
             expect(label).toEqual(DEFAULT_LABEL)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getLabel(INVALID_ENTITY_ID),
-            )
         })
     })
 
@@ -112,7 +100,7 @@ describe('TodoistApi label endpoints', () => {
         }
 
         test('calls post on restClient with expected parameters', async () => {
-            const labelId = 123
+            const labelId = '123'
             const requestMock = setupRestClientMock(DEFAULT_LABEL, 204)
             const api = getTarget()
 
@@ -134,22 +122,15 @@ describe('TodoistApi label endpoints', () => {
             setupRestClientMock(returnedTask, 204)
             const api = getTarget()
 
-            const result = await api.updateLabel(123, DEFAULT_UPDATE_LABEL_ARGS)
+            const result = await api.updateLabel('123', DEFAULT_UPDATE_LABEL_ARGS)
 
             expect(result).toEqual(returnedTask)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () =>
-                    await getTarget().updateLabel(INVALID_ENTITY_ID, DEFAULT_UPDATE_LABEL_ARGS),
-            )
         })
     })
 
     describe('deleteLabel', () => {
         test('calls delete on expected label', async () => {
-            const labelId = 123
+            const labelId = '123'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -170,15 +151,9 @@ describe('TodoistApi label endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const result = await api.deleteLabel(123)
+            const result = await api.deleteLabel('123')
 
             expect(result).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().deleteLabel(INVALID_ENTITY_ID),
-            )
         })
     })
 })

--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -4,7 +4,7 @@ import {
     DEFAULT_PROJECT,
     DEFAULT_REQUEST_ID,
     DEFAULT_USER,
-    INVALID_ENTITY_ID,
+    PROJECT_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
     getRestBaseUri,
@@ -12,7 +12,6 @@ import {
     ENDPOINT_REST_PROJECT_COLLABORATORS,
 } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
-import { assertInputValidationError } from './testUtils/asserts'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
@@ -21,7 +20,7 @@ function getTarget() {
 describe('TodoistApi project endpoints', () => {
     describe('getProject', () => {
         test('calls get request with expected url', async () => {
-            const projectId = 12
+            const projectId = '12'
             const requestMock = setupRestClientMock(DEFAULT_PROJECT)
             const api = getTarget()
 
@@ -40,15 +39,9 @@ describe('TodoistApi project endpoints', () => {
             setupRestClientMock(DEFAULT_PROJECT)
             const api = getTarget()
 
-            const project = await api.getProject(123)
+            const project = await api.getProject('123')
 
             expect(project).toEqual(DEFAULT_PROJECT)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getProject(INVALID_ENTITY_ID),
-            )
         })
     })
 
@@ -69,7 +62,7 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            const projects = [DEFAULT_PROJECT]
+            const projects = [DEFAULT_PROJECT, PROJECT_WITH_OPTIONALS_AS_NULL]
             setupRestClientMock(projects)
             const api = getTarget()
 
@@ -114,7 +107,7 @@ describe('TodoistApi project endpoints', () => {
     describe('updateProject', () => {
         const DEFAULT_UPDATE_PROJECT_ARGS = { name: 'a name' }
         test('calls post on restClient with expected parameters', async () => {
-            const projectId = 123
+            const projectId = '123'
             const updateArgs = { name: 'a new name' }
             const requestMock = setupRestClientMock(DEFAULT_PROJECT, 204)
             const api = getTarget()
@@ -137,22 +130,15 @@ describe('TodoistApi project endpoints', () => {
             setupRestClientMock(returnedProject, 204)
             const api = getTarget()
 
-            const result = await api.updateProject(123, DEFAULT_UPDATE_PROJECT_ARGS)
+            const result = await api.updateProject('123', DEFAULT_UPDATE_PROJECT_ARGS)
 
             expect(result).toEqual(returnedProject)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () =>
-                    await getTarget().updateProject(INVALID_ENTITY_ID, DEFAULT_UPDATE_PROJECT_ARGS),
-            )
         })
     })
 
     describe('deleteProject', () => {
         test('calls delete on expected project', async () => {
-            const projectId = 123
+            const projectId = '123'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -172,20 +158,14 @@ describe('TodoistApi project endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const result = await api.deleteProject(123)
+            const result = await api.deleteProject('123')
 
             expect(result).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().deleteProject(INVALID_ENTITY_ID),
-            )
         })
     })
 
     describe('getProjectCollaborators', () => {
-        const projectId = 123
+        const projectId = '123'
         const users = [DEFAULT_USER]
 
         test('calls get on expected endpoint', async () => {
@@ -210,12 +190,6 @@ describe('TodoistApi project endpoints', () => {
             const returnedUsers = await api.getProjectCollaborators(projectId)
 
             expect(returnedUsers).toEqual(users)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getProjectCollaborators(INVALID_ENTITY_ID),
-            )
         })
     })
 })

--- a/src/TodoistApi.sections.test.ts
+++ b/src/TodoistApi.sections.test.ts
@@ -1,13 +1,7 @@
 import { TodoistApi } from '.'
-import {
-    DEFAULT_AUTH_TOKEN,
-    DEFAULT_REQUEST_ID,
-    DEFAULT_SECTION,
-    INVALID_ENTITY_ID,
-} from './testUtils/testDefaults'
+import { DEFAULT_AUTH_TOKEN, DEFAULT_REQUEST_ID, DEFAULT_SECTION } from './testUtils/testDefaults'
 import { getRestBaseUri, ENDPOINT_REST_SECTIONS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
-import { assertInputValidationError } from './testUtils/asserts'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
@@ -16,7 +10,7 @@ function getTarget() {
 describe('TodoistApi section endpoints', () => {
     describe('getSection', () => {
         test('calls get request with expected url', async () => {
-            const sectionId = 12
+            const sectionId = '12'
             const requestMock = setupRestClientMock(DEFAULT_SECTION)
             const api = getTarget()
 
@@ -35,15 +29,9 @@ describe('TodoistApi section endpoints', () => {
             setupRestClientMock(DEFAULT_SECTION)
             const api = getTarget()
 
-            const section = await api.getSection(123)
+            const section = await api.getSection('123')
 
             expect(section).toEqual(DEFAULT_SECTION)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getSection(INVALID_ENTITY_ID),
-            )
         })
     })
 
@@ -113,7 +101,7 @@ describe('TodoistApi section endpoints', () => {
         const DEFAULT_UPDATE_SECTION_ARGS = { name: 'a new name' }
 
         test('calls post on restClient with expected parameters', async () => {
-            const sectionId = 123
+            const sectionId = '123'
             const requestMock = setupRestClientMock(DEFAULT_SECTION, 204)
             const api = getTarget()
 
@@ -135,22 +123,15 @@ describe('TodoistApi section endpoints', () => {
             setupRestClientMock(returnedSection, 204)
             const api = getTarget()
 
-            const response = await api.updateSection(123, DEFAULT_UPDATE_SECTION_ARGS)
+            const response = await api.updateSection('123', DEFAULT_UPDATE_SECTION_ARGS)
 
             expect(response).toEqual(returnedSection)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () =>
-                    await getTarget().updateSection(INVALID_ENTITY_ID, DEFAULT_UPDATE_SECTION_ARGS),
-            )
         })
     })
 
     describe('deleteSection', () => {
         test('calls delete on expected section', async () => {
-            const sectionId = 123
+            const sectionId = '123'
             const requestMock = setupRestClientMock(true)
             const api = getTarget()
 
@@ -171,15 +152,9 @@ describe('TodoistApi section endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const response = await api.deleteSection(123)
+            const response = await api.deleteSection('123')
 
             expect(response).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().deleteSection(INVALID_ENTITY_ID),
-            )
         })
     })
 })

--- a/src/TodoistApi.tasks.test.ts
+++ b/src/TodoistApi.tasks.test.ts
@@ -6,7 +6,7 @@ import {
     DEFAULT_QUICK_ADD_RESPONSE,
     DEFAULT_REQUEST_ID,
     DEFAULT_TASK,
-    INVALID_ENTITY_ID,
+    TASK_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
     getRestBaseUri,
@@ -17,7 +17,6 @@ import {
     ENDPOINT_SYNC_QUICK_ADD,
 } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
-import { assertInputValidationError } from './testUtils/asserts'
 
 function setupSyncTaskConverter(returnedTask: Task) {
     return jest.spyOn(taskConverters, 'getTaskFromQuickAddResponse').mockReturnValue(returnedTask)
@@ -81,7 +80,7 @@ describe('TodoistApi task endpoints', () => {
         const DEFAULT_UPDATE_TASK_ARGS = { content: 'some new content' }
 
         test('calls post on restClient with expected parameters', async () => {
-            const taskId = 123
+            const taskId = '123'
             const requestMock = setupRestClientMock(DEFAULT_TASK, 204)
             const api = getTarget()
 
@@ -103,22 +102,15 @@ describe('TodoistApi task endpoints', () => {
             setupRestClientMock(returnedTask, 204)
             const api = getTarget()
 
-            const response = await api.updateTask(123, DEFAULT_UPDATE_TASK_ARGS)
+            const response = await api.updateTask('123', DEFAULT_UPDATE_TASK_ARGS)
 
             expect(response).toEqual(returnedTask)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () =>
-                    await getTarget().updateTask(INVALID_ENTITY_ID, { content: 'some content' }),
-            )
         })
     })
 
     describe('closeTask', () => {
         test('calls post on close endpoint', async () => {
-            const taskId = 123
+            const taskId = '123'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -139,21 +131,15 @@ describe('TodoistApi task endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const response = await api.closeTask(123)
+            const response = await api.closeTask('123')
 
             expect(response).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().closeTask(INVALID_ENTITY_ID),
-            )
         })
     })
 
     describe('reopenTask', () => {
         test('calls post on reopen endpoint', async () => {
-            const taskId = 123
+            const taskId = '123'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -174,21 +160,15 @@ describe('TodoistApi task endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const response = await api.reopenTask(123)
+            const response = await api.reopenTask('123')
 
             expect(response).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().reopenTask(INVALID_ENTITY_ID),
-            )
         })
     })
 
     describe('deleteTask', () => {
         test('calls delete on expected task', async () => {
-            const taskId = 123
+            const taskId = '123'
             const requestMock = setupRestClientMock(undefined, 204)
             const api = getTarget()
 
@@ -209,15 +189,9 @@ describe('TodoistApi task endpoints', () => {
             setupRestClientMock(undefined, 204)
             const api = getTarget()
 
-            const response = await api.deleteTask(123)
+            const response = await api.deleteTask('123')
 
             expect(response).toEqual(true)
-        })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().deleteTask(INVALID_ENTITY_ID),
-            )
         })
     })
 
@@ -260,7 +234,7 @@ describe('TodoistApi task endpoints', () => {
 
     describe('getTask', () => {
         test('calls get request with expected url', async () => {
-            const taskId = 12
+            const taskId = '12'
             const requestMock = setupRestClientMock(DEFAULT_TASK)
             const api = getTarget()
 
@@ -274,12 +248,6 @@ describe('TodoistApi task endpoints', () => {
                 DEFAULT_AUTH_TOKEN,
             )
         })
-
-        test('throws validation error for invalid id input', async () => {
-            await assertInputValidationError(
-                async () => await getTarget().getTask(INVALID_ENTITY_ID),
-            )
-        })
     })
 
     describe('getTasks', () => {
@@ -288,7 +256,7 @@ describe('TodoistApi task endpoints', () => {
         }
 
         test('calls get on expected endpoint with args', async () => {
-            const requestMock = setupRestClientMock([DEFAULT_TASK])
+            const requestMock = setupRestClientMock([DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL])
             const api = getTarget()
 
             await api.getTasks(DEFAULT_GET_TASKS_ARGS)

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -1,3 +1,4 @@
+import { String } from 'runtypes'
 import {
     Task,
     QuickAddTaskResponse,
@@ -6,7 +7,6 @@ import {
     User,
     Section,
     Comment,
-    Int,
 } from './types/entities'
 import {
     AddLabelArgs,
@@ -81,12 +81,12 @@ export class TodoistApi {
     private restApiBase: string
     private syncApiBase: string
 
-    async getTask(id: number): Promise<Task> {
-        Int.check(id)
+    async getTask(id: string): Promise<Task> {
+        String.check(id)
         const response = await request<Task>(
             'GET',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, id),
             this.authToken,
         )
 
@@ -132,12 +132,12 @@ export class TodoistApi {
         return validateTask(task)
     }
 
-    async updateTask(id: number, args: UpdateTaskArgs, requestId?: string): Promise<Task> {
-        Int.check(id)
+    async updateTask(id: string, args: UpdateTaskArgs, requestId?: string): Promise<Task> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, id),
             this.authToken,
             args,
             requestId,
@@ -145,12 +145,12 @@ export class TodoistApi {
         return validateTask(response.data)
     }
 
-    async closeTask(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async closeTask(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_CLOSE),
+            generatePath(ENDPOINT_REST_TASKS, id, ENDPOINT_REST_TASK_CLOSE),
             this.authToken,
             undefined,
             requestId,
@@ -158,12 +158,12 @@ export class TodoistApi {
         return isSuccess(response)
     }
 
-    async reopenTask(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async reopenTask(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_TASKS, String(id), ENDPOINT_REST_TASK_REOPEN),
+            generatePath(ENDPOINT_REST_TASKS, id, ENDPOINT_REST_TASK_REOPEN),
             this.authToken,
             undefined,
             requestId,
@@ -171,12 +171,12 @@ export class TodoistApi {
         return isSuccess(response)
     }
 
-    async deleteTask(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async deleteTask(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'DELETE',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_TASKS, String(id)),
+            generatePath(ENDPOINT_REST_TASKS, id),
             this.authToken,
             undefined,
             requestId,
@@ -184,12 +184,12 @@ export class TodoistApi {
         return isSuccess(response)
     }
 
-    async getProject(id: number): Promise<Project> {
-        Int.check(id)
+    async getProject(id: string): Promise<Project> {
+        String.check(id)
         const response = await request<Project>(
             'GET',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, id),
             this.authToken,
         )
 
@@ -220,12 +220,12 @@ export class TodoistApi {
         return validateProject(response.data)
     }
 
-    async updateProject(id: number, args: UpdateProjectArgs, requestId?: string): Promise<Project> {
-        Int.check(id)
+    async updateProject(id: string, args: UpdateProjectArgs, requestId?: string): Promise<Project> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, id),
             this.authToken,
             args,
             requestId,
@@ -233,28 +233,24 @@ export class TodoistApi {
         return validateProject(response.data)
     }
 
-    async deleteProject(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async deleteProject(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'DELETE',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_PROJECTS, String(id)),
+            generatePath(ENDPOINT_REST_PROJECTS, id),
             this.authToken,
             requestId,
         )
         return isSuccess(response)
     }
 
-    async getProjectCollaborators(projectId: number): Promise<User[]> {
-        Int.check(projectId)
+    async getProjectCollaborators(projectId: string): Promise<User[]> {
+        String.check(projectId)
         const response = await request<User[]>(
             'GET',
             this.restApiBase,
-            generatePath(
-                ENDPOINT_REST_PROJECTS,
-                String(projectId),
-                ENDPOINT_REST_PROJECT_COLLABORATORS,
-            ),
+            generatePath(ENDPOINT_REST_PROJECTS, projectId, ENDPOINT_REST_PROJECT_COLLABORATORS),
             this.authToken,
         )
 
@@ -273,12 +269,12 @@ export class TodoistApi {
         return validateSectionArray(response.data)
     }
 
-    async getSection(id: number): Promise<Section> {
-        Int.check(id)
+    async getSection(id: string): Promise<Section> {
+        String.check(id)
         const response = await request<Section>(
             'GET',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, id),
             this.authToken,
         )
 
@@ -298,12 +294,12 @@ export class TodoistApi {
         return validateSection(response.data)
     }
 
-    async updateSection(id: number, args: UpdateSectionArgs, requestId?: string): Promise<Section> {
-        Int.check(id)
+    async updateSection(id: string, args: UpdateSectionArgs, requestId?: string): Promise<Section> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, id),
             this.authToken,
             args,
             requestId,
@@ -311,12 +307,12 @@ export class TodoistApi {
         return validateSection(response.data)
     }
 
-    async deleteSection(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async deleteSection(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'DELETE',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_SECTIONS, String(id)),
+            generatePath(ENDPOINT_REST_SECTIONS, id),
             this.authToken,
             undefined,
             requestId,
@@ -327,12 +323,12 @@ export class TodoistApi {
     /**
      * Fetches a personal label
      */
-    async getLabel(id: number): Promise<Label> {
-        Int.check(id)
+    async getLabel(id: string): Promise<Label> {
+        String.check(id)
         const response = await request<Label>(
             'GET',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, id),
             this.authToken,
         )
 
@@ -372,12 +368,12 @@ export class TodoistApi {
     /**
      * Updates a personal label
      */
-    async updateLabel(id: number, args: UpdateLabelArgs, requestId?: string): Promise<Label> {
-        Int.check(id)
+    async updateLabel(id: string, args: UpdateLabelArgs, requestId?: string): Promise<Label> {
+        String.check(id)
         const response = await request(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, id),
             this.authToken,
             args,
             requestId,
@@ -388,12 +384,12 @@ export class TodoistApi {
     /**
      * Deletes a personal label
      */
-    async deleteLabel(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async deleteLabel(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'DELETE',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_LABELS, String(id)),
+            generatePath(ENDPOINT_REST_LABELS, id),
             this.authToken,
             undefined,
             requestId,
@@ -444,12 +440,12 @@ export class TodoistApi {
         return validateCommentArray(response.data)
     }
 
-    async getComment(id: number): Promise<Comment> {
-        Int.check(id)
+    async getComment(id: string): Promise<Comment> {
+        String.check(id)
         const response = await request<Comment>(
             'GET',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, id),
             this.authToken,
         )
 
@@ -472,12 +468,12 @@ export class TodoistApi {
         return validateComment(response.data)
     }
 
-    async updateComment(id: number, args: UpdateCommentArgs, requestId?: string): Promise<Comment> {
-        Int.check(id)
+    async updateComment(id: string, args: UpdateCommentArgs, requestId?: string): Promise<Comment> {
+        String.check(id)
         const response = await request<boolean>(
             'POST',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, id),
             this.authToken,
             args,
             requestId,
@@ -485,12 +481,12 @@ export class TodoistApi {
         return validateComment(response.data)
     }
 
-    async deleteComment(id: number, requestId?: string): Promise<boolean> {
-        Int.check(id)
+    async deleteComment(id: string, requestId?: string): Promise<boolean> {
+        String.check(id)
         const response = await request(
             'DELETE',
             this.restApiBase,
-            generatePath(ENDPOINT_REST_COMMENTS, String(id)),
+            generatePath(ENDPOINT_REST_COMMENTS, id),
             this.authToken,
             undefined,
             requestId,

--- a/src/testUtils/testDefaults.ts
+++ b/src/testUtils/testDefaults.ts
@@ -36,7 +36,7 @@ const DEFAULT_COMMENT_CONTENT = 'A comment'
 export const DEFAULT_AUTH_TOKEN = 'AToken'
 export const DEFAULT_REQUEST_ID = 'ARequestID'
 
-export const INVALID_ENTITY_ID = 'invalid/entity/id' as unknown as number
+export const INVALID_ENTITY_ID = 1234
 
 export const DEFAULT_DUE_DATE = {
     isRecurring: false,
@@ -96,6 +96,15 @@ export const INVALID_TASK = {
     due: INVALID_DUE_DATE,
 }
 
+export const TASK_WITH_OPTIONALS_AS_NULL: Task = {
+    ...DEFAULT_TASK,
+    due: null,
+    assigneeId: null,
+    assignerId: null,
+    parentId: null,
+    sectionId: null,
+}
+
 export const DEFAULT_PROJECT: Project = {
     id: DEFAULT_PROJECT_ID,
     name: DEFAULT_PROJECT_NAME,
@@ -114,6 +123,11 @@ export const DEFAULT_PROJECT: Project = {
 export const INVALID_PROJECT = {
     ...DEFAULT_PROJECT,
     name: 123,
+}
+
+export const PROJECT_WITH_OPTIONALS_AS_NULL: Project = {
+    ...DEFAULT_PROJECT,
+    parentId: null,
 }
 
 export const DEFAULT_SECTION: Section = {
@@ -175,4 +189,33 @@ export const DEFAULT_COMMENT: Comment = {
 export const INVALID_COMMENT = {
     ...DEFAULT_COMMENT,
     attachment: INVALID_ATTACHMENT,
+}
+
+export const COMMENT_WITH_OPTIONALS_AS_NULL_TASK: Comment = {
+    ...DEFAULT_COMMENT,
+    projectId: null,
+    attachment: null,
+}
+
+export const COMMENT_WITH_ATTACHMENT_WITH_OPTIONALS_AS_NULL: Comment = {
+    ...DEFAULT_COMMENT,
+    attachment: {
+        ...DEFAULT_ATTACHMENT,
+        fileName: null,
+        fileSize: null,
+        fileType: null,
+        fileDuration: null,
+        uploadState: null,
+        image: null,
+        imageWidth: null,
+        imageHeight: null,
+        url: null,
+        title: null,
+    },
+}
+
+export const COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT: Comment = {
+    ...DEFAULT_COMMENT,
+    taskId: null,
+    attachment: null,
 }

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -8,6 +8,7 @@ import {
     Partial,
     Literal,
     Union,
+    Null,
 } from 'runtypes'
 
 export const Int = NumberRunType.withConstraint(
@@ -15,7 +16,7 @@ export const Int = NumberRunType.withConstraint(
 )
 
 export type TodoistEntity = {
-    id: number
+    id: string
 }
 
 export type OrderedEntity = TodoistEntity & {
@@ -32,8 +33,8 @@ export const DueDate = Record({
     date: String,
 }).And(
     Partial({
-        datetime: String,
-        timezone: String,
+        datetime: String.Or(Null),
+        timezone: String.Or(Null),
     }),
 )
 
@@ -54,11 +55,11 @@ export const Task = Record({
     creatorId: String,
 }).And(
     Partial({
-        due: DueDate,
-        assigneeId: String,
-        assignerId: String,
-        parentId: String,
-        sectionId: String,
+        due: DueDate.Or(Null),
+        assigneeId: String.Or(Null),
+        assignerId: String.Or(Null),
+        parentId: String.Or(Null),
+        sectionId: String.Or(Null),
     }),
 )
 
@@ -78,7 +79,7 @@ export const Project = Record({
     viewStyle: String,
 }).And(
     Partial({
-        parentId: String,
+        parentId: String.Or(Null),
     }),
 )
 
@@ -107,17 +108,17 @@ export const Attachment = Record({
     resourceType: String,
 }).And(
     Partial({
-        fileName: String,
-        fileSize: Int,
-        fileType: String,
-        fileUrl: String,
-        fileDuration: Int,
-        uploadState: Union(Literal('pending'), Literal('completed')),
-        image: String,
-        imageWidth: Int,
-        imageHeight: Int,
-        url: String,
-        title: String,
+        fileName: String.Or(Null),
+        fileSize: Int.Or(Null),
+        fileType: String.Or(Null),
+        fileUrl: String.Or(Null),
+        fileDuration: Int.Or(Null),
+        uploadState: Union(Literal('pending'), Literal('completed')).Or(Null),
+        image: String.Or(Null),
+        imageWidth: Int.Or(Null),
+        imageHeight: Int.Or(Null),
+        url: String.Or(Null),
+        title: String.Or(Null),
     }),
 )
 
@@ -129,9 +130,9 @@ export const Comment = Record({
     postedAt: String,
 }).And(
     Partial({
-        taskId: String,
-        projectId: String,
-        attachment: Attachment,
+        taskId: String.Or(Null),
+        projectId: String.Or(Null),
+        attachment: Attachment.Or(Null),
     }),
 )
 
@@ -145,7 +146,8 @@ export const User = Record({
 
 export type User = Static<typeof User>
 
-export type Color = TodoistEntity & {
+export type Color = {
+    id: number
     name: string
     value: string
 }


### PR DESCRIPTION
Fixes: #133 

Fields that weren't being returned in v1 of the REST API may now be returned but have a value of `null`. Our validation wasn't catering for that. Have updated the partial types to accept the type or NULL.

There were a few other instances of number-based ID usage that hadn't been switched. These have now been corrected.

## Testing

You can try and follow the instructions in the readme using the `scratch.ts` file in order to test this.

``` typescript
import { TodoistApi } from './TodoistApi'

const token = '<TOKEN>'

const api = new TodoistApi(token)

async function doIt() {
    try {
        const projects = await api.getProjects()
        console.log(projects.length)
    } catch (error: unknown) {
        if (error instanceof Error) {
            console.log(error)
        }
        console.log({ error })
    }
}

doIt().catch(() => {
    // noop
})
```
I found putting breakpoints on the console.logs allowed me to see the problem. Prior to the fix, the ones in the catch would get hit, post-fix, the one inside the try would get hit.

I have updated all the tests to account for all of the partial/nulls though.