### PR TITLE
chore: Corrects one final id number type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -27,7 +27,7 @@ export type GetTasksArgs = {
     label?: string
     filter?: string
     lang?: string
-    ids?: number[]
+    ids?: string[]
 }
 
 export type UpdateTaskArgs = {


### PR DESCRIPTION
In the `GetTasksArgs` type there was one remaining field using numbers instead of strings, that of `ids`.