### PR TITLE
fix: Corrects the call when an array of ids is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -150,6 +150,7 @@ describe('TodoistApi project endpoints', () => {
                 getRestBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
+                undefined,
                 DEFAULT_REQUEST_ID,
             )
         })

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -240,6 +240,7 @@ export class TodoistApi {
             this.restApiBase,
             generatePath(ENDPOINT_REST_PROJECTS, id),
             this.authToken,
+            undefined,
             requestId,
         )
         return isSuccess(response)
@@ -263,7 +264,7 @@ export class TodoistApi {
             this.restApiBase,
             ENDPOINT_REST_SECTIONS,
             this.authToken,
-            projectId && { projectId },
+            projectId ? { projectId } : undefined,
         )
 
         return validateSectionArray(response.data)

--- a/src/restClient.axios.test.ts
+++ b/src/restClient.axios.test.ts
@@ -1,0 +1,18 @@
+import axios from 'axios'
+import { paramsSerializer } from './restClient'
+
+const DEFAULT_BASE_URI = 'https://api.todoist.com/rest/v2/tasks'
+
+describe('axios tests without mocking', () => {
+    test('GET calls serialise arrays correctly', () => {
+        const requestUri = axios.create().getUri({
+            method: 'GET',
+            baseURL: DEFAULT_BASE_URI,
+            params: {
+                ids: ['12345', '56789'],
+            },
+            paramsSerializer,
+        })
+        expect(requestUri).toEqual('https://api.todoist.com/rest/v2/tasks?ids=12345%2C56789')
+    })
+})

--- a/src/restClient.test.ts
+++ b/src/restClient.test.ts
@@ -118,9 +118,12 @@ describe('restClient', () => {
         await request('GET', DEFAULT_BASE_URI, DEFAULT_ENDPOINT, DEFAULT_AUTH_TOKEN)
 
         expect(axiosMock.get).toBeCalledTimes(1)
-        expect(axiosMock.get).toBeCalledWith(DEFAULT_ENDPOINT, {
-            params: undefined,
-        })
+        expect(axiosMock.get).toBeCalledWith(
+            DEFAULT_ENDPOINT,
+            expect.objectContaining({
+                params: undefined,
+            }),
+        )
     })
 
     test('get passes params to axios', async () => {
@@ -133,9 +136,12 @@ describe('restClient', () => {
         )
 
         expect(axiosMock.get).toBeCalledTimes(1)
-        expect(axiosMock.get).toBeCalledWith(DEFAULT_ENDPOINT, {
-            params: DEFAULT_PAYLOAD,
-        })
+        expect(axiosMock.get).toBeCalledWith(
+            DEFAULT_ENDPOINT,
+            expect.objectContaining({
+                params: DEFAULT_PAYLOAD,
+            }),
+        )
     })
 
     test('get returns response from axios', async () => {

--- a/src/restClient.test.ts
+++ b/src/restClient.test.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosStatic, AxiosResponse, AxiosError } from 'axios'
-import { request, isSuccess } from './restClient'
+import { request, isSuccess, paramsSerializer } from './restClient'
 import { TodoistRequestError } from './types/errors'
 import * as caseConverter from 'axios-case-converter'
 import { assertInstance } from './testUtils/asserts'
@@ -118,12 +118,10 @@ describe('restClient', () => {
         await request('GET', DEFAULT_BASE_URI, DEFAULT_ENDPOINT, DEFAULT_AUTH_TOKEN)
 
         expect(axiosMock.get).toBeCalledTimes(1)
-        expect(axiosMock.get).toBeCalledWith(
-            DEFAULT_ENDPOINT,
-            expect.objectContaining({
-                params: undefined,
-            }),
-        )
+        expect(axiosMock.get).toBeCalledWith(DEFAULT_ENDPOINT, {
+            params: undefined,
+            paramsSerializer,
+        })
     })
 
     test('get passes params to axios', async () => {
@@ -136,12 +134,10 @@ describe('restClient', () => {
         )
 
         expect(axiosMock.get).toBeCalledTimes(1)
-        expect(axiosMock.get).toBeCalledWith(
-            DEFAULT_ENDPOINT,
-            expect.objectContaining({
-                params: DEFAULT_PAYLOAD,
-            }),
-        )
+        expect(axiosMock.get).toBeCalledWith(DEFAULT_ENDPOINT, {
+            params: DEFAULT_PAYLOAD,
+            paramsSerializer,
+        })
     })
 
     test('get returns response from axios', async () => {


### PR DESCRIPTION
Fixes: https://github.com/Doist/todoist-api-typescript/issues/131

The problem with passing in just an array of objects into axios is it may not do what we're expecting it to do when it comes to formatting. This was exactly what was happening. 

In this PR I'm adding a custom `paramsSerializer` function to ensure that formatting is as we want it.

### Testing

You can try this out with the `scratch.ts` file (see readme for usage). Make sure you set your token and a couple of task IDs for your account.

With this fix, you will get just those two tasks returned, prior to this fix, it would have returned _all_ your tasks.

``` Typescript
import { TodoistApi } from './TodoistApi'

const token = '<TOKEN>'

const api = new TodoistApi(token)

async function doIt() {
    try {
        const tasks = await api.getTasks({
            ids: ['<YOUR_TASK_1>', '<YOUR_TASK_2>'],
        })
        console.log(tasks.length)
    } catch (error: unknown) {
        if (error instanceof Error) {
            console.log(error)
        }
        console.log({ error })
    }
}

doIt().catch(() => {
    // noop
})
```

