### PR TITLE
fix: Allow passing null assigneeId and dueString to unset field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/todoist-api-typescript",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -39,7 +39,7 @@ export type UpdateTaskArgs = {
     dueLang?: string
     dueDate?: string
     dueDatetime?: string
-    assigneeId?: string
+    assigneeId?: string | null
 }
 
 export type ProjectViewStyle = 'list' | 'board'

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -35,10 +35,10 @@ export type UpdateTaskArgs = {
     description?: string
     labels?: string[]
     priority?: number
-    dueString?: string
-    dueLang?: string
-    dueDate?: string
-    dueDatetime?: string
+    dueString?: string | null
+    dueLang?: string | null
+    dueDate?: string | null
+    dueDatetime?: string | null
     assigneeId?: string | null
 }
 


### PR DESCRIPTION
When updating a task via the Todoist API SDK, we want to be able to unset the `assignee_id` field. Following the documentation (https://developer.todoist.com/rest/v2/#update-a-task) this can be done by passing in the `null` value. This PR is to allow for said `null` value to be passed as well.

We want to do the same thing for the `dueString` field (and all the other `due`-related fields).

This is needed for our new Task Helper UI Extension (https://github.com/Doist/event-integrations/pull/1117).