### PR TITLE
fix: Change EntityInHierarchy.parentId to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -24,7 +24,7 @@ export type OrderedEntity = TodoistEntity & {
 }
 
 export type EntityInHierarchy = OrderedEntity & {
-    parentId?: number
+    parentId?: string
 }
 
 export const DueDate = Record({


### PR DESCRIPTION
While working on https://github.com/Doist/integrations-backlog/issues/418 (upgrade `Todoist-Outlook` to API v2), I've noticed that some of the errors and test failures looks something like:
```
      Type '{ ...; }' is not assignable to type 'EntityInHierarchyWithIndent'.
        Type '{ ...; }' is not assignable to type 'Partial<EntityInHierarchy>'.
          Types of property 'parentId' are incompatible.
            Type 'string | null | undefined' is not assignable to type 'number | undefined'.
              Type 'null' is not assignable to type 'number | undefined'.
```

Since the API v2 now treats all `id`s as strings (i.e. `projectId`s, `sectionId`s, `taskId`s, etc.), it makes sense to change this `EntityInHierarchy.parentId` to string as well.

This is apparently only used in `Todoist-Outlook` (https://github.com/search?l=TypeScript&q=org%3ADoist+EntityInHierarchy&type=Code) so this seems like a safe change.