### PR TITLE
chore: Add publishing to GitHub package registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ jobs:
             - name: Git checkout
               uses: actions/checkout@v3
 
+            # Remove any registry configurations from .nvmrc
+            - run: sed -i "/@doist/d" ./.nvmrc
+
             - name: Configure doist package repository
               uses: actions/setup-node@v3
               with:
@@ -27,3 +30,13 @@ jobs:
               run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+            # Publish to GitHub package registry
+            - uses: actions/setup-node@v3
+              with:
+                  node-version-file: .nvmrc
+                  scope: '@doist'
+                  registry-url: 'https://npm.pkg.github.com/'
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
 v16
+@doist:registry=https://npm.pkg.github.com/


### PR DESCRIPTION
## Overview

In this PR, we are updating the `publish` action to create a package in the (private) GitHub package registry in addition to the (public) npm package registry. This will allow us to consume the package in projects that use private @doist-scoped packages.

The impetus for this change is that I couldn't upgrade the `@doist/todoist-api-typescript` package to > 2.0.0 in https://github.com/Doist/todoist-addtask-integrations/, since that project is set up to pull @doist packages from the GitHub package registry. We cross-publish other public packages, like reactist, in both registries, so I think we should do the same here.

@scottlovegrove @henningmu @engfragui Do you know of any reasons why we _shouldn't_ make this change?