### PR TITLE
fix: Allow null values for EntityInHierarchy.parentId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -24,7 +24,7 @@ export type OrderedEntity = TodoistEntity & {
 }
 
 export type EntityInHierarchy = OrderedEntity & {
-    parentId?: string
+    parentId?: string | null
 }
 
 export const DueDate = Record({


### PR DESCRIPTION
Follow up to https://github.com/Doist/todoist-api-typescript/pull/157, as `parentId` should be allowed a `null` value as well.