### PR TITLE
feat: Add getColorByInternalName utility function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/todoist-api-typescript",
-    "version": "2.0.8",
+    "version": "2.1.0",
     "description": "A typescript wrapper for the Todoist REST API.",
     "author": "Doist developers",
     "repository": "git@github.com:doist/todoist-api-typescript.git",

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -147,9 +147,29 @@ export const User = Record({
 export type User = Static<typeof User>
 
 export type Color = {
+    /**
+     * @deprecated No longer used in API
+     */
     id: number
+    /**
+     * The key of the color (i.e. 'berry_red')
+     */
+    key: string
+    /**
+     * The display name of the color (i.e. 'Berry Red')
+     */
+    displayName: string
+    /**
+     * @deprecated Use {@link displayName} instead
+     */
     name: string
-    internalName: string
+    /**
+     * The hex value of the color (i.e. '#b8255f')
+     */
+    hexValue: string
+    /**
+     * @deprecated Use {@link hexValue} instead
+     */
     value: string
 }
 

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -149,6 +149,7 @@ export type User = Static<typeof User>
 export type Color = {
     id: number
     name: string
+    internalName: string
     value: string
 }
 

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -148,7 +148,7 @@ export type User = Static<typeof User>
 
 export type Color = {
     /**
-     * @deprecated No longer used in API
+     * @deprecated No longer used
      */
     id: number
     /**

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -160,7 +160,7 @@ export type Color = {
      */
     displayName: string
     /**
-     * @deprecated Use {@link displayName} instead
+     * @deprecated Use {@link Color.displayName} instead
      */
     name: string
     /**
@@ -168,7 +168,7 @@ export type Color = {
      */
     hexValue: string
     /**
-     * @deprecated Use {@link hexValue} instead
+     * @deprecated Use {@link Color.hexValue} instead
      */
     value: string
 }

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -3,7 +3,7 @@ import {
     taupe,
     getColorById,
     getColorByName,
-    getColorByInternalName,
+    getColorByKey,
     defaultColor,
 } from './colors'
 
@@ -35,7 +35,7 @@ describe('getColorByName', () => {
     })
 })
 
-describe('getColorByInternalName', () => {
+describe('getColorByKey', () => {
     const colorTheories = [
         ['berry_red', berryRed],
         ['taupe', taupe],
@@ -43,8 +43,8 @@ describe('getColorByInternalName', () => {
         ['Some non existing color', defaultColor], // does not exist, defaulted
     ] as const
 
-    test.each(colorTheories)('internalName %p returns color %p', (internalName, expected) => {
-        const color = getColorByInternalName(internalName)
+    test.each(colorTheories)('key %p returns color %p', (key, expected) => {
+        const color = getColorByKey(key)
         expect(color).toEqual(expected)
     })
 })

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -1,6 +1,13 @@
-import { berryRed, charcoal, taupe, getColorById } from './colors'
+import {
+    berryRed,
+    charcoal,
+    taupe,
+    getColorById,
+    getColorByName,
+    getColorByInternalName,
+} from './colors'
 
-describe('getColor', () => {
+describe('getColorById', () => {
     const colorTheories = [
         [0, charcoal], // out of range, defaulted
         [30, berryRed],
@@ -10,6 +17,33 @@ describe('getColor', () => {
 
     test.each(colorTheories)('id %p returns color %p', (id, expected) => {
         const color = getColorById(id)
+        expect(color).toEqual(expected)
+    })
+})
+
+describe('getColorByName', () => {
+    const colorTheories = [
+        ['Berry Red', berryRed],
+        ['Taupe', taupe],
+        ['Some non existing color', charcoal], // does not exist, defaulted
+    ] as const
+
+    test.each(colorTheories)('name %p returns color %p', (name, expected) => {
+        const color = getColorByName(name)
+        expect(color).toEqual(expected)
+    })
+})
+
+describe('getColorByInternalName', () => {
+    const colorTheories = [
+        ['berry_red', berryRed],
+        ['taupe', taupe],
+        ['Berry Red', charcoal], // does not exist, defaulted
+        ['Some non existing color', charcoal], // does not exist, defaulted
+    ] as const
+
+    test.each(colorTheories)('internalName %p returns color %p', (internalName, expected) => {
+        const color = getColorByInternalName(internalName)
         expect(color).toEqual(expected)
     })
 })

--- a/src/utils/colors.test.ts
+++ b/src/utils/colors.test.ts
@@ -1,18 +1,18 @@
 import {
     berryRed,
-    charcoal,
     taupe,
     getColorById,
     getColorByName,
     getColorByInternalName,
+    defaultColor,
 } from './colors'
 
 describe('getColorById', () => {
     const colorTheories = [
-        [0, charcoal], // out of range, defaulted
+        [0, defaultColor], // out of range, defaulted
         [30, berryRed],
         [49, taupe],
-        [999, charcoal], // out of range, defaulted
+        [999, defaultColor], // out of range, defaulted
     ] as const
 
     test.each(colorTheories)('id %p returns color %p', (id, expected) => {
@@ -25,7 +25,8 @@ describe('getColorByName', () => {
     const colorTheories = [
         ['Berry Red', berryRed],
         ['Taupe', taupe],
-        ['Some non existing color', charcoal], // does not exist, defaulted
+        ['berry_red', defaultColor], // does not exist, defaulted
+        ['Some non existing color', defaultColor], // does not exist, defaulted
     ] as const
 
     test.each(colorTheories)('name %p returns color %p', (name, expected) => {
@@ -38,8 +39,8 @@ describe('getColorByInternalName', () => {
     const colorTheories = [
         ['berry_red', berryRed],
         ['taupe', taupe],
-        ['Berry Red', charcoal], // does not exist, defaulted
-        ['Some non existing color', charcoal], // does not exist, defaulted
+        ['Berry Red', defaultColor], // does not exist, defaulted
+        ['Some non existing color', defaultColor], // does not exist, defaulted
     ] as const
 
     test.each(colorTheories)('internalName %p returns color %p', (internalName, expected) => {

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,25 +1,70 @@
 import { Color } from '../types'
 
-export const berryRed: Color = { name: 'Berry Red', id: 30, value: '#b8255f' }
-export const red: Color = { name: 'Red', id: 31, value: '#db4035' }
-export const orange: Color = { name: 'Orange', id: 32, value: '#ff9933' }
-export const yellow: Color = { name: 'Yellow', id: 33, value: '#fad000' }
-export const oliveGreen: Color = { name: 'Olive Green', id: 34, value: '#afb83b' }
-export const limeGreen: Color = { name: 'Lime Green', id: 35, value: '#7ecc49' }
-export const green: Color = { name: 'Green', id: 36, value: '#299438' }
-export const mintGreen: Color = { name: 'Mint Green', id: 37, value: '#6accbc' }
-export const turquoise: Color = { name: 'Turquoise', id: 38, value: '#158fad' }
-export const skyBlue: Color = { name: 'Sky Blue', id: 39, value: '#14aaf5' }
-export const lightBlue: Color = { name: 'Light Blue', id: 40, value: '#96c3eb' }
-export const blue: Color = { name: 'Blue', id: 41, value: '#4073ff' }
-export const grape: Color = { name: 'Grape', id: 42, value: '#884dff' }
-export const violet: Color = { name: 'Violet', id: 43, value: '#af38eb' }
-export const lavender: Color = { name: 'Lavender', id: 44, value: '#eb96eb' }
-export const magenta: Color = { name: 'Magenta', id: 45, value: '#e05194' }
-export const salmon: Color = { name: 'Salmon', id: 46, value: '#ff8d85' }
-export const charcoal: Color = { name: 'Charcoal', id: 47, value: '#808080' }
-export const gray: Color = { name: 'Gray', id: 48, value: '#b8b8b8' }
-export const taupe: Color = { name: 'Taupe', id: 49, value: '#ccac93' }
+export const berryRed: Color = {
+    name: 'Berry Red',
+    internalName: 'berry_red',
+    id: 30,
+    value: '#b8255f',
+}
+export const red: Color = { name: 'Red', internalName: 'red', id: 31, value: '#db4035' }
+export const orange: Color = { name: 'Orange', internalName: 'orange', id: 32, value: '#ff9933' }
+export const yellow: Color = { name: 'Yellow', internalName: 'yellow', id: 33, value: '#fad000' }
+export const oliveGreen: Color = {
+    name: 'Olive Green',
+    internalName: 'olive_green',
+    id: 34,
+    value: '#afb83b',
+}
+export const limeGreen: Color = {
+    name: 'Lime Green',
+    internalName: 'lime_green',
+    id: 35,
+    value: '#7ecc49',
+}
+export const green: Color = { name: 'Green', internalName: 'green', id: 36, value: '#299438' }
+export const mintGreen: Color = {
+    name: 'Mint Green',
+    internalName: 'mint_green',
+    id: 37,
+    value: '#6accbc',
+}
+export const turquoise: Color = {
+    name: 'Turquoise',
+    internalName: 'turquoise',
+    id: 38,
+    value: '#158fad',
+}
+export const skyBlue: Color = {
+    name: 'Sky Blue',
+    internalName: 'sky_blue',
+    id: 39,
+    value: '#14aaf5',
+}
+export const lightBlue: Color = {
+    name: 'Light Blue',
+    internalName: 'light_blue',
+    id: 40,
+    value: '#96c3eb',
+}
+export const blue: Color = { name: 'Blue', internalName: 'blue', id: 41, value: '#4073ff' }
+export const grape: Color = { name: 'Grape', internalName: 'grape', id: 42, value: '#884dff' }
+export const violet: Color = { name: 'Violet', internalName: 'violet', id: 43, value: '#af38eb' }
+export const lavender: Color = {
+    name: 'Lavender',
+    internalName: 'lavender',
+    id: 44,
+    value: '#eb96eb',
+}
+export const magenta: Color = { name: 'Magenta', internalName: 'magenta', id: 45, value: '#e05194' }
+export const salmon: Color = { name: 'Salmon', internalName: 'salmon', id: 46, value: '#ff8d85' }
+export const charcoal: Color = {
+    name: 'Charcoal',
+    internalName: 'charcoal',
+    id: 47,
+    value: '#808080',
+}
+export const gray: Color = { name: 'Gray', internalName: 'gray', id: 48, value: '#b8b8b8' }
+export const taupe: Color = { name: 'Taupe', internalName: 'taupe', id: 49, value: '#ccac93' }
 
 export const colors = [
     berryRed,
@@ -44,12 +89,19 @@ export const colors = [
     taupe,
 ]
 
+const defaultColor: Color = charcoal
+
 export function getColorById(colorId: number): Color {
     const color = colors.find((color) => color.id === colorId)
-    return color ?? charcoal
+    return color ?? defaultColor
 }
 
 export function getColorByName(colorName: string): Color {
     const color = colors.find((color) => color.name === colorName)
-    return color ?? charcoal
+    return color ?? defaultColor
+}
+
+export function getColorByInternalName(colorInternalName: string): Color {
+    const color = colors.find((color) => color.internalName === colorInternalName)
+    return color ?? defaultColor
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,70 +1,165 @@
 import { Color } from '../types'
 
 export const berryRed: Color = {
-    name: 'Berry Red',
-    internalName: 'berry_red',
     id: 30,
+    key: 'berry_red',
+    displayName: 'Berry Red',
+    name: 'Berry Red',
+    hexValue: '#b8255f',
     value: '#b8255f',
-}
-export const red: Color = { name: 'Red', internalName: 'red', id: 31, value: '#db4035' }
-export const orange: Color = { name: 'Orange', internalName: 'orange', id: 32, value: '#ff9933' }
-export const yellow: Color = { name: 'Yellow', internalName: 'yellow', id: 33, value: '#fad000' }
+} as const
+export const red: Color = {
+    id: 31,
+    key: 'red',
+    displayName: 'Red',
+    name: 'Red',
+    hexValue: '#db4035',
+    value: '#db4035',
+} as const
+export const orange: Color = {
+    id: 32,
+    key: 'orange',
+    displayName: 'Orange',
+    name: 'Orange',
+    hexValue: '#ff9933',
+    value: '#ff9933',
+} as const
+export const yellow: Color = {
+    id: 33,
+    key: 'yellow',
+    displayName: 'Yellow',
+    name: 'Yellow',
+    hexValue: '#fad000',
+    value: '#fad000',
+} as const
 export const oliveGreen: Color = {
-    name: 'Olive Green',
-    internalName: 'olive_green',
     id: 34,
+    key: 'olive_green',
+    displayName: 'Olive Green',
+    name: 'Olive Green',
+    hexValue: '#afb83b',
     value: '#afb83b',
-}
+} as const
 export const limeGreen: Color = {
-    name: 'Lime Green',
-    internalName: 'lime_green',
     id: 35,
+    key: 'lime_green',
+    displayName: 'Lime Green',
+    name: 'Lime Green',
+    hexValue: '#7ecc49',
     value: '#7ecc49',
-}
-export const green: Color = { name: 'Green', internalName: 'green', id: 36, value: '#299438' }
+} as const
+export const green: Color = {
+    id: 36,
+    key: 'green',
+    displayName: 'Green',
+    name: 'Green',
+    hexValue: '#299438',
+    value: '#299438',
+} as const
 export const mintGreen: Color = {
-    name: 'Mint Green',
-    internalName: 'mint_green',
     id: 37,
+    key: 'mint_green',
+    displayName: 'Mint Green',
+    name: 'Mint Green',
+    hexValue: '#6accbc',
     value: '#6accbc',
-}
+} as const
 export const turquoise: Color = {
-    name: 'Turquoise',
-    internalName: 'turquoise',
     id: 38,
+    key: 'turquoise',
+    displayName: 'Turquoise',
+    name: 'Turquoise',
+    hexValue: '#158fad',
     value: '#158fad',
-}
+} as const
 export const skyBlue: Color = {
-    name: 'Sky Blue',
-    internalName: 'sky_blue',
     id: 39,
+    key: 'sky_blue',
+    displayName: 'Sky Blue',
+    name: 'Sky Blue',
+    hexValue: '#14aaf5',
     value: '#14aaf5',
-}
+} as const
 export const lightBlue: Color = {
-    name: 'Light Blue',
-    internalName: 'light_blue',
     id: 40,
+    key: 'light_blue',
+    displayName: 'Light Blue',
+    name: 'Light Blue',
+    hexValue: '#96c3eb',
     value: '#96c3eb',
-}
-export const blue: Color = { name: 'Blue', internalName: 'blue', id: 41, value: '#4073ff' }
-export const grape: Color = { name: 'Grape', internalName: 'grape', id: 42, value: '#884dff' }
-export const violet: Color = { name: 'Violet', internalName: 'violet', id: 43, value: '#af38eb' }
+} as const
+export const blue: Color = {
+    id: 41,
+    key: 'blue',
+    displayName: 'Blue',
+    name: 'Blue',
+    hexValue: '#4073ff',
+    value: '#4073ff',
+} as const
+export const grape: Color = {
+    id: 42,
+    key: 'grape',
+    displayName: 'Grape',
+    name: 'Grape',
+    hexValue: '#884dff',
+    value: '#884dff',
+} as const
+export const violet: Color = {
+    id: 43,
+    key: 'violet',
+    displayName: 'Violet',
+    name: 'Violet',
+    hexValue: '#af38eb',
+    value: '#af38eb',
+} as const
 export const lavender: Color = {
-    name: 'Lavender',
-    internalName: 'lavender',
     id: 44,
+    key: 'lavender',
+    displayName: 'Lavender',
+    name: 'Lavender',
+    hexValue: '#eb96eb',
     value: '#eb96eb',
-}
-export const magenta: Color = { name: 'Magenta', internalName: 'magenta', id: 45, value: '#e05194' }
-export const salmon: Color = { name: 'Salmon', internalName: 'salmon', id: 46, value: '#ff8d85' }
+} as const
+export const magenta: Color = {
+    id: 45,
+    key: 'magenta',
+    displayName: 'Magenta',
+    name: 'Magenta',
+    hexValue: '#e05194',
+    value: '#e05194',
+} as const
+export const salmon: Color = {
+    id: 46,
+    key: 'salmon',
+    displayName: 'Salmon',
+    name: 'Salmon',
+    hexValue: '#ff8d85',
+    value: '#ff8d85',
+} as const
 export const charcoal: Color = {
-    name: 'Charcoal',
-    internalName: 'charcoal',
     id: 47,
+    key: 'charcoal',
+    displayName: 'Charcoal',
+    name: 'Charcoal',
+    hexValue: '#808080',
     value: '#808080',
-}
-export const gray: Color = { name: 'Gray', internalName: 'gray', id: 48, value: '#b8b8b8' }
-export const taupe: Color = { name: 'Taupe', internalName: 'taupe', id: 49, value: '#ccac93' }
+} as const
+export const gray: Color = {
+    id: 48,
+    key: 'gray',
+    displayName: 'Gray',
+    name: 'Gray',
+    hexValue: '#b8b8b8',
+    value: '#b8b8b8',
+} as const
+export const taupe: Color = {
+    id: 49,
+    key: 'taupe',
+    displayName: 'Taupe',
+    name: 'Taupe',
+    hexValue: '#ccac93',
+    value: '#ccac93',
+} as const
 
 export const colors = [
     berryRed,
@@ -87,21 +182,27 @@ export const colors = [
     charcoal,
     gray,
     taupe,
-]
+] as const
 
 export const defaultColor: Color = charcoal
 
+/**
+ * @deprecated Use {@link getColorByKey} instead
+ */
 export function getColorById(colorId: number): Color {
     const color = colors.find((color) => color.id === colorId)
     return color ?? defaultColor
 }
 
+/**
+ * @deprecated Use {@link getColorByKey} instead
+ */
 export function getColorByName(colorName: string): Color {
     const color = colors.find((color) => color.name === colorName)
     return color ?? defaultColor
 }
 
-export function getColorByKey(colorInternalName: string): Color {
-    const color = colors.find((color) => color.internalName === colorInternalName)
+export function getColorByKey(colorKey: string): Color {
+    const color = colors.find((color) => color.key === colorKey)
     return color ?? defaultColor
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -101,7 +101,7 @@ export function getColorByName(colorName: string): Color {
     return color ?? defaultColor
 }
 
-export function getColorByInternalName(colorInternalName: string): Color {
+export function getColorByKey(colorInternalName: string): Color {
     const color = colors.find((color) => color.internalName === colorInternalName)
     return color ?? defaultColor
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -89,7 +89,7 @@ export const colors = [
     taupe,
 ]
 
-const defaultColor: Color = charcoal
+export const defaultColor: Color = charcoal
 
 export function getColorById(colorId: number): Color {
     const color = colors.find((color) => color.id === colorId)


### PR DESCRIPTION
### Overview 

While working on upgrading `Todoist-Outlook` to Todoist API v2 by leveraging `todoist-api-typescript` v2 (https://github.com/Doist/Todoist-Outlook/pull/609), I've noticed that we don't currently have a way to retrieve a `Color` object (https://github.com/Doist/todoist-api-typescript/blob/main/src/types/entities.ts#L149-L153) via its "internal name", which is what is saved in the `Project.color` field.

As an example, there's no way to map "berry_red" to a `Color`.

This PR adds a utility function that does that (+ some simple tests).

### Reference 

Blocks https://github.com/Doist/Todoist-Outlook/pull/609

### Alternatives considered

We (briefly?) considered restructuring the `Color` type so that its `name` would map to the "internal name" (i.e. "berry_red") and `displayName` to its... errr... display name (i.e. "Berry Red"). However, this would be a breaking change and would require bumping `todoist-api-typescript` to v3.