### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Configure doist package repository
               uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         timeout-minutes: 31
         steps:
             - name: Git checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             # Remove any registry configurations from .nvmrc
             - run: sed -i "/@doist/d" ./.nvmrc


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
