### PR TITLE
chore: add `type-fest` as peer dependency to fix types relying on it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,11 @@
                 "rimraf": "3.0.2",
                 "ts-jest": "29.0.5",
                 "ts-node": "10.9.1",
-                "type-fest": "^4.5.0",
+                "type-fest": "^4.12.0",
                 "typescript": "4.9.5"
+            },
+            "peerDependencies": {
+                "type-fest": "^4.5.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -7561,9 +7564,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.5.0.tgz",
-            "integrity": "sha512-diLQivFzddJl4ylL3jxSkEc39Tpw7o1QeEHIPxVwryDK2lpB7Nqhzhuo6v5/Ls08Z0yPSAhsyAWlv1/H0ciNmw==",
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
+            "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
             "dev": true,
             "engines": {
                 "node": ">=16"
@@ -13647,9 +13650,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.5.0.tgz",
-            "integrity": "sha512-diLQivFzddJl4ylL3jxSkEc39Tpw7o1QeEHIPxVwryDK2lpB7Nqhzhuo6v5/Ls08Z0yPSAhsyAWlv1/H0ciNmw==",
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz",
+            "integrity": "sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==",
             "dev": true
         },
         "typed-array-length": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,11 @@
         "rimraf": "3.0.2",
         "ts-jest": "29.0.5",
         "ts-node": "10.9.1",
-        "type-fest": "^4.5.0",
+        "type-fest": "^4.12.0",
         "typescript": "4.9.5"
+    },
+    "peerDependencies": {
+        "type-fest": "^4.12.0"
     },
     "prettier": "@doist/prettier-config",
     "husky": {


### PR DESCRIPTION
Added `type-fest` as peer dependency to fix types relying on it (closes #254).

Additionally, bumped `type-fest` to latest version, since there are no breaking changes. 