### PR TITLE
fix: remove request id when calling the sync api

### DIFF
--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -1,6 +1,6 @@
 const BASE_URI = 'https://api.todoist.com'
 const API_REST_BASE_URI = '/rest/v2/'
-const API_SYNC_BASE_URI = '/sync/v9/'
+export const API_SYNC_BASE_URI = '/sync/v9/'
 const TODOIST_URI = 'https://todoist.com'
 const API_AUTHORIZATION_BASE_URI = '/oauth/'
 

--- a/src/restClient.test.ts
+++ b/src/restClient.test.ts
@@ -5,6 +5,7 @@ import { TodoistRequestError } from './types/errors'
 import * as caseConverter from 'axios-case-converter'
 import { assertInstance } from './testUtils/asserts'
 import { DEFAULT_REQUEST_ID } from './testUtils/testDefaults'
+import { API_SYNC_BASE_URI } from './consts/endpoints'
 
 const RANDOM_ID = 'SomethingRandom'
 
@@ -190,6 +191,16 @@ describe('restClient', () => {
         expect(axiosMock.create).toBeCalledWith({
             baseURL: DEFAULT_BASE_URI,
             headers: { ...AUTHORIZATION_HEADERS, 'X-Request-Id': RANDOM_ID },
+        })
+    })
+
+    test('random request ID is not created if none provided for POST request on the sync endpoint', async () => {
+        const syncUrl = new URL(API_SYNC_BASE_URI, DEFAULT_BASE_URI).toString()
+        await request('POST', syncUrl, DEFAULT_ENDPOINT, DEFAULT_AUTH_TOKEN, DEFAULT_PAYLOAD)
+
+        expect(axiosMock.create).toBeCalledWith({
+            baseURL: syncUrl,
+            headers: { ...AUTHORIZATION_HEADERS },
         })
     })
 

--- a/src/restClient.ts
+++ b/src/restClient.ts
@@ -5,6 +5,7 @@ import { TodoistRequestError } from './types/errors'
 import { HttpMethod } from './types/http'
 import { v4 as uuidv4 } from 'uuid'
 import axiosRetry from 'axios-retry'
+import { API_SYNC_BASE_URI } from './consts/endpoints'
 
 export function paramsSerializer(params: Record<string, unknown>) {
     const qs = new URLSearchParams()
@@ -96,7 +97,8 @@ export async function request<T>(
     const originalStack = new Error()
 
     try {
-        if (httpMethod === 'POST' && !requestId) {
+        // Sync api don't allow a request id in the CORS
+        if (httpMethod === 'POST' && !requestId && !baseUri.includes(API_SYNC_BASE_URI)) {
             requestId = uuidv4()
         }
 


### PR DESCRIPTION
## Description

This PR introduces changes to the `restClient` module to handle POST requests to the sync API endpoint differently. 

Resolves #257 

### Changes
- Export the `API_SYNC_BASE_URI` constant from the `endpoints` module to make it accessible in other modules
- Modify the `request` function in `restClient` to skip generating a random request ID for POST requests to the sync API endpoint
- Add a test case in `restClient.test.ts` to verify that a random request ID is not created for POST requests to the sync API endpoint

### Rationale
The sync API endpoint does not allow a request ID in the CORS headers. To accommodate this, the `request` function now checks if the `baseUri` includes the `API_SYNC_BASE_URI` before generating a random request ID for POST requests. This ensures that POST requests to the sync API endpoint do not include a request ID, while other POST requests continue to generate a random request ID if none is provided.

### Testing
A new test case has been added to `restClient.test.ts` to verify that a random request ID is not created when making a POST request to the sync API endpoint. 

Please review the changes and provide any feedback or suggestions.