### PR TITLE
feat: [BREAKING] migrate from REST API to Sync API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is the official TypeScript API client for the Todoist REST API.
 
+> [!IMPORTANT]  
+> This library is currently being migrated from the Todoist REST API to the Todoist Sync API. As a result, parts of the documentation may be outdated. However, the client API remains consistent with the latest stable release, [v3.0.3](https://github.com/Doist/todoist-api-typescript/releases/tag/v3.0.3). Please note that some client methods may return unexpected data or encounter failures during this transition.
+
 ## Installation
 
 ```

--- a/src/TodoistApi.comments.test.ts
+++ b/src/TodoistApi.comments.test.ts
@@ -20,7 +20,7 @@ describe('TodoistApi comment endpoints', () => {
             const getCommentsArgs = { projectId: '12', limit: 10, cursor: '0' }
             const requestMock = setupRestClientMock({
                 results: [DEFAULT_COMMENT],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 
@@ -43,7 +43,7 @@ describe('TodoistApi comment endpoints', () => {
                 COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT,
                 COMMENT_WITH_ATTACHMENT_WITH_OPTIONALS_AS_NULL,
             ]
-            setupRestClientMock({ results: expectedComments, next_cursor: '123' })
+            setupRestClientMock({ results: expectedComments, nextCursor: '123' })
             const api = getTarget()
 
             const { results: comments, nextCursor } = await api.getComments({ taskId: '12' })

--- a/src/TodoistApi.comments.test.ts
+++ b/src/TodoistApi.comments.test.ts
@@ -7,7 +7,7 @@ import {
     DEFAULT_COMMENT,
     DEFAULT_REQUEST_ID,
 } from './testUtils/testDefaults'
-import { getRestBaseUri, ENDPOINT_REST_COMMENTS } from './consts/endpoints'
+import { getSyncBaseUri, ENDPOINT_REST_COMMENTS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 
 function getTarget() {
@@ -17,8 +17,11 @@ function getTarget() {
 describe('TodoistApi comment endpoints', () => {
     describe('getComments', () => {
         test('calls get request with expected params', async () => {
-            const getCommentsArgs = { projectId: '12' }
-            const requestMock = setupRestClientMock([DEFAULT_COMMENT])
+            const getCommentsArgs = { projectId: '12', limit: 10, cursor: '0' }
+            const requestMock = setupRestClientMock({
+                results: [DEFAULT_COMMENT],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
             await api.getComments(getCommentsArgs)
@@ -26,7 +29,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_COMMENTS,
                 DEFAULT_AUTH_TOKEN,
                 getCommentsArgs,
@@ -40,12 +43,13 @@ describe('TodoistApi comment endpoints', () => {
                 COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT,
                 COMMENT_WITH_ATTACHMENT_WITH_OPTIONALS_AS_NULL,
             ]
-            setupRestClientMock(expectedComments)
+            setupRestClientMock({ results: expectedComments, next_cursor: '123' })
             const api = getTarget()
 
-            const comments = await api.getComments({ taskId: '12' })
+            const { results: comments, nextCursor } = await api.getComments({ taskId: '12' })
 
             expect(comments).toEqual(expectedComments)
+            expect(nextCursor).toBe('123')
         })
     })
 
@@ -60,7 +64,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${commentId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -92,7 +96,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_COMMENTS,
                 DEFAULT_AUTH_TOKEN,
                 addCommentArgs,
@@ -126,7 +130,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateCommentArgs,
@@ -156,7 +160,7 @@ describe('TodoistApi comment endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_COMMENTS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.labels.test.ts
+++ b/src/TodoistApi.labels.test.ts
@@ -39,7 +39,7 @@ describe('TodoistApi label endpoints', () => {
         test('calls get on labels endpoint', async () => {
             const requestMock = setupRestClientMock({
                 results: [DEFAULT_LABEL],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 
@@ -62,7 +62,7 @@ describe('TodoistApi label endpoints', () => {
             const labels = [DEFAULT_LABEL]
             setupRestClientMock({
                 results: [DEFAULT_LABEL],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 

--- a/src/TodoistApi.labels.test.ts
+++ b/src/TodoistApi.labels.test.ts
@@ -1,6 +1,6 @@
 import { TodoistApi } from '.'
 import { DEFAULT_AUTH_TOKEN, DEFAULT_LABEL, DEFAULT_REQUEST_ID } from './testUtils/testDefaults'
-import { getRestBaseUri, ENDPOINT_REST_LABELS } from './consts/endpoints'
+import { getSyncBaseUri, ENDPOINT_REST_LABELS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 
 function getTarget() {
@@ -19,7 +19,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -37,28 +37,39 @@ describe('TodoistApi label endpoints', () => {
 
     describe('getLabels', () => {
         test('calls get on labels endpoint', async () => {
-            const requestMock = setupRestClientMock([DEFAULT_LABEL])
+            const requestMock = setupRestClientMock({
+                results: [DEFAULT_LABEL],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
-            await api.getLabels()
+            await api.getLabels({ limit: 10, cursor: '0' })
 
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_LABELS,
                 DEFAULT_AUTH_TOKEN,
+                {
+                    limit: 10,
+                    cursor: '0',
+                },
             )
         })
 
         test('returns result from rest client', async () => {
             const labels = [DEFAULT_LABEL]
-            setupRestClientMock(labels)
+            setupRestClientMock({
+                results: [DEFAULT_LABEL],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
-            const response = await api.getLabels()
+            const { results, nextCursor } = await api.getLabels()
 
-            expect(response).toEqual(labels)
+            expect(results).toEqual(labels)
+            expect(nextCursor).toBe('123')
         })
     })
 
@@ -76,7 +87,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_LABELS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_LABEL_ARGS,
@@ -109,7 +120,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_UPDATE_LABEL_ARGS,
@@ -139,7 +150,7 @@ describe('TodoistApi label endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_LABELS}/${labelId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -49,7 +49,7 @@ describe('TodoistApi project endpoints', () => {
         test('calls get on projects endpoint', async () => {
             const requestMock = setupRestClientMock({
                 results: [DEFAULT_PROJECT],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 
@@ -68,7 +68,7 @@ describe('TodoistApi project endpoints', () => {
 
         test('returns result from rest client', async () => {
             const projects = [DEFAULT_PROJECT, PROJECT_WITH_OPTIONALS_AS_NULL]
-            setupRestClientMock({ results: projects, next_cursor: '123' })
+            setupRestClientMock({ results: projects, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getProjects()
@@ -176,7 +176,7 @@ describe('TodoistApi project endpoints', () => {
         const users = [DEFAULT_USER]
 
         test('calls get on expected endpoint', async () => {
-            const requestMock = setupRestClientMock({ results: users, next_cursor: '123' })
+            const requestMock = setupRestClientMock({ results: users, nextCursor: '123' })
             const api = getTarget()
 
             const args = { limit: 10, cursor: '0' }
@@ -193,7 +193,7 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock({ results: users, next_cursor: '123' })
+            setupRestClientMock({ results: users, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getProjectCollaborators(projectId)

--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -7,7 +7,7 @@ import {
     PROJECT_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
-    getRestBaseUri,
+    getSyncBaseUri,
     ENDPOINT_REST_PROJECTS,
     ENDPOINT_REST_PROJECT_COLLABORATORS,
 } from './consts/endpoints'
@@ -29,7 +29,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -47,28 +47,34 @@ describe('TodoistApi project endpoints', () => {
 
     describe('getProjects', () => {
         test('calls get on projects endpoint', async () => {
-            const requestMock = setupRestClientMock([DEFAULT_PROJECT])
+            const requestMock = setupRestClientMock({
+                results: [DEFAULT_PROJECT],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
-            await api.getProjects()
+            const args = { limit: 10, cursor: '0' }
+            await api.getProjects(args)
 
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_PROJECTS,
                 DEFAULT_AUTH_TOKEN,
+                args,
             )
         })
 
         test('returns result from rest client', async () => {
             const projects = [DEFAULT_PROJECT, PROJECT_WITH_OPTIONALS_AS_NULL]
-            setupRestClientMock(projects)
+            setupRestClientMock({ results: projects, next_cursor: '123' })
             const api = getTarget()
 
-            const response = await api.getProjects()
+            const { results, nextCursor } = await api.getProjects()
 
-            expect(response).toEqual(projects)
+            expect(results).toEqual(projects)
+            expect(nextCursor).toBe('123')
         })
     })
 
@@ -86,7 +92,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_PROJECTS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_PROJECT_ARGS,
@@ -117,7 +123,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
                 updateArgs,
@@ -147,7 +153,7 @@ describe('TodoistApi project endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -170,27 +176,30 @@ describe('TodoistApi project endpoints', () => {
         const users = [DEFAULT_USER]
 
         test('calls get on expected endpoint', async () => {
-            const requestMock = setupRestClientMock(users)
+            const requestMock = setupRestClientMock({ results: users, next_cursor: '123' })
             const api = getTarget()
 
-            await api.getProjectCollaborators(projectId)
+            const args = { limit: 10, cursor: '0' }
+            await api.getProjectCollaborators(projectId, args)
 
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_PROJECTS}/${projectId}/${ENDPOINT_REST_PROJECT_COLLABORATORS}`,
                 DEFAULT_AUTH_TOKEN,
+                args,
             )
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock(users)
+            setupRestClientMock({ results: users, next_cursor: '123' })
             const api = getTarget()
 
-            const returnedUsers = await api.getProjectCollaborators(projectId)
+            const { results, nextCursor } = await api.getProjectCollaborators(projectId)
 
-            expect(returnedUsers).toEqual(users)
+            expect(results).toEqual(users)
+            expect(nextCursor).toBe('123')
         })
     })
 })

--- a/src/TodoistApi.sections.test.ts
+++ b/src/TodoistApi.sections.test.ts
@@ -1,6 +1,6 @@
 import { TodoistApi } from '.'
 import { DEFAULT_AUTH_TOKEN, DEFAULT_REQUEST_ID, DEFAULT_SECTION } from './testUtils/testDefaults'
-import { getRestBaseUri, ENDPOINT_REST_SECTIONS } from './consts/endpoints'
+import { getSyncBaseUri, ENDPOINT_REST_SECTIONS } from './consts/endpoints'
 import { setupRestClientMock } from './testUtils/mocks'
 
 function getTarget() {
@@ -19,7 +19,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -38,29 +38,34 @@ describe('TodoistApi section endpoints', () => {
     describe('getSections', () => {
         test('calls get on sections endpoint', async () => {
             const projectId = '123'
-            const requestMock = setupRestClientMock([DEFAULT_SECTION])
+            const requestMock = setupRestClientMock({
+                results: [DEFAULT_SECTION],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
-            await api.getSections(projectId)
+            const args = { projectId, limit: 10, cursor: '0' }
+            await api.getSections(args)
 
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_SECTIONS,
                 DEFAULT_AUTH_TOKEN,
-                { projectId },
+                args,
             )
         })
 
         test('returns result from rest client', async () => {
             const sections = [DEFAULT_SECTION]
-            setupRestClientMock(sections)
+            setupRestClientMock({ results: sections, next_cursor: '123' })
             const api = getTarget()
 
-            const response = await api.getSections()
+            const { results, nextCursor } = await api.getSections({ projectId: '123' })
 
-            expect(response).toEqual(sections)
+            expect(results).toEqual(sections)
+            expect(nextCursor).toBe('123')
         })
     })
 
@@ -79,7 +84,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_SECTIONS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_SECTION_ARGS,
@@ -110,7 +115,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_UPDATE_SECTION_ARGS,
@@ -140,7 +145,7 @@ describe('TodoistApi section endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_SECTIONS}/${sectionId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,

--- a/src/TodoistApi.sections.test.ts
+++ b/src/TodoistApi.sections.test.ts
@@ -40,7 +40,7 @@ describe('TodoistApi section endpoints', () => {
             const projectId = '123'
             const requestMock = setupRestClientMock({
                 results: [DEFAULT_SECTION],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 
@@ -59,7 +59,7 @@ describe('TodoistApi section endpoints', () => {
 
         test('returns result from rest client', async () => {
             const sections = [DEFAULT_SECTION]
-            setupRestClientMock({ results: sections, next_cursor: '123' })
+            setupRestClientMock({ results: sections, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getSections({ projectId: '123' })

--- a/src/TodoistApi.tasks.test.ts
+++ b/src/TodoistApi.tasks.test.ts
@@ -259,7 +259,7 @@ describe('TodoistApi task endpoints', () => {
         test('calls get on expected endpoint with args', async () => {
             const requestMock = setupRestClientMock({
                 results: [DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL],
-                next_cursor: '123',
+                nextCursor: '123',
             })
             const api = getTarget()
 
@@ -277,7 +277,7 @@ describe('TodoistApi task endpoints', () => {
 
         test('returns result from rest client', async () => {
             const tasks = [DEFAULT_TASK]
-            setupRestClientMock({ results: tasks, next_cursor: '123' })
+            setupRestClientMock({ results: tasks, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getTasks(DEFAULT_GET_TASKS_ARGS)

--- a/src/TodoistApi.tasks.test.ts
+++ b/src/TodoistApi.tasks.test.ts
@@ -9,7 +9,6 @@ import {
     TASK_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
-    getRestBaseUri,
     getSyncBaseUri,
     ENDPOINT_REST_TASK_CLOSE,
     ENDPOINT_REST_TASK_REOPEN,
@@ -41,7 +40,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_TASKS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_TASK_ARGS,
@@ -58,7 +57,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri('https://staging.todoist.com'),
+                getSyncBaseUri('https://staging.todoist.com'),
                 ENDPOINT_REST_TASKS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_ADD_TASK_ARGS,
@@ -89,7 +88,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_UPDATE_TASK_ARGS,
@@ -119,7 +118,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}/${ENDPOINT_REST_TASK_CLOSE}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -148,7 +147,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}/${ENDPOINT_REST_TASK_REOPEN}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -177,7 +176,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'DELETE',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
                 undefined,
@@ -243,7 +242,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 `${ENDPOINT_REST_TASKS}/${taskId}`,
                 DEFAULT_AUTH_TOKEN,
             )
@@ -253,10 +252,15 @@ describe('TodoistApi task endpoints', () => {
     describe('getTasks', () => {
         const DEFAULT_GET_TASKS_ARGS = {
             projectId: '123',
+            limit: 10,
+            cursor: '0',
         }
 
         test('calls get on expected endpoint with args', async () => {
-            const requestMock = setupRestClientMock([DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL])
+            const requestMock = setupRestClientMock({
+                results: [DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL],
+                next_cursor: '123',
+            })
             const api = getTarget()
 
             await api.getTasks(DEFAULT_GET_TASKS_ARGS)
@@ -264,7 +268,7 @@ describe('TodoistApi task endpoints', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'GET',
-                getRestBaseUri(),
+                getSyncBaseUri(),
                 ENDPOINT_REST_TASKS,
                 DEFAULT_AUTH_TOKEN,
                 DEFAULT_GET_TASKS_ARGS,
@@ -273,12 +277,13 @@ describe('TodoistApi task endpoints', () => {
 
         test('returns result from rest client', async () => {
             const tasks = [DEFAULT_TASK]
-            setupRestClientMock(tasks)
+            setupRestClientMock({ results: tasks, next_cursor: '123' })
             const api = getTarget()
 
-            const response = await api.getTasks(DEFAULT_GET_TASKS_ARGS)
+            const { results, nextCursor } = await api.getTasks(DEFAULT_GET_TASKS_ARGS)
 
-            expect(response).toEqual(tasks)
+            expect(results).toEqual(tasks)
+            expect(nextCursor).toBe('123')
         })
     })
 })

--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -2,6 +2,7 @@ import { getAuthorizationUrl, getAuthToken, revokeAuthToken, Permission } from '
 import { setupRestClientMock } from './testUtils/mocks'
 import { assertInstance } from './testUtils/asserts'
 import { TodoistRequestError } from './types'
+import { getSyncBaseUri } from './consts/endpoints'
 
 describe('authentication', () => {
     describe('getAuthorizationUrl', () => {
@@ -144,7 +145,7 @@ describe('authentication', () => {
             expect(requestMock).toBeCalledTimes(1)
             expect(requestMock).toBeCalledWith(
                 'POST',
-                'https://api.todoist.com/sync/v9/',
+                getSyncBaseUri(),
                 'access_tokens/revoke',
                 undefined,
                 revokeTokenRequest,

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -1,15 +1,15 @@
 const BASE_URI = 'https://api.todoist.com'
-const API_REST_BASE_URI = '/rest/v2/'
-export const API_SYNC_BASE_URI = '/sync/v9/'
 const TODOIST_URI = 'https://todoist.com'
+
+// The API version is not configurable, to ensure
+// compatibility between the API and the client.
+export const API_VERSION = 'v9.208'
+
+export const API_BASE_URI = `/api/${API_VERSION}/`
 const API_AUTHORIZATION_BASE_URI = '/oauth/'
 
-export function getRestBaseUri(domainBase: string = BASE_URI): string {
-    return new URL(API_REST_BASE_URI, domainBase).toString()
-}
-
 export function getSyncBaseUri(domainBase: string = BASE_URI): string {
-    return new URL(API_SYNC_BASE_URI, domainBase).toString()
+    return new URL(API_BASE_URI, domainBase).toString()
 }
 
 export function getAuthBaseUri(domainBase: string = TODOIST_URI): string {
@@ -28,7 +28,7 @@ export const ENDPOINT_REST_TASK_CLOSE = 'close'
 export const ENDPOINT_REST_TASK_REOPEN = 'reopen'
 export const ENDPOINT_REST_PROJECT_COLLABORATORS = 'collaborators'
 
-export const ENDPOINT_SYNC_QUICK_ADD = 'quick/add'
+export const ENDPOINT_SYNC_QUICK_ADD = 'quick'
 
 export const ENDPOINT_AUTHORIZATION = 'authorize'
 export const ENDPOINT_GET_TOKEN = 'access_token'

--- a/src/restClient.test.ts
+++ b/src/restClient.test.ts
@@ -5,7 +5,7 @@ import { TodoistRequestError } from './types/errors'
 import * as caseConverter from 'axios-case-converter'
 import { assertInstance } from './testUtils/asserts'
 import { DEFAULT_REQUEST_ID } from './testUtils/testDefaults'
-import { API_SYNC_BASE_URI } from './consts/endpoints'
+import { API_BASE_URI } from './consts/endpoints'
 
 const RANDOM_ID = 'SomethingRandom'
 
@@ -195,7 +195,7 @@ describe('restClient', () => {
     })
 
     test('random request ID is not created if none provided for POST request on the sync endpoint', async () => {
-        const syncUrl = new URL(API_SYNC_BASE_URI, DEFAULT_BASE_URI).toString()
+        const syncUrl = new URL(API_BASE_URI, DEFAULT_BASE_URI).toString()
         await request('POST', syncUrl, DEFAULT_ENDPOINT, DEFAULT_AUTH_TOKEN, DEFAULT_PAYLOAD)
 
         expect(axiosMock.create).toBeCalledWith({

--- a/src/restClient.ts
+++ b/src/restClient.ts
@@ -5,7 +5,7 @@ import { TodoistRequestError } from './types/errors'
 import { HttpMethod } from './types/http'
 import { v4 as uuidv4 } from 'uuid'
 import axiosRetry from 'axios-retry'
-import { API_SYNC_BASE_URI } from './consts/endpoints'
+import { API_BASE_URI } from './consts/endpoints'
 
 export function paramsSerializer(params: Record<string, unknown>) {
     const qs = new URLSearchParams()
@@ -98,7 +98,7 @@ export async function request<T>(
 
     try {
         // Sync api don't allow a request id in the CORS
-        if (httpMethod === 'POST' && !requestId && !baseUri.includes(API_SYNC_BASE_URI)) {
+        if (httpMethod === 'POST' && !requestId && !baseUri.includes(API_BASE_URI)) {
             requestId = uuidv4()
         }
 

--- a/src/testUtils/testDefaults.ts
+++ b/src/testUtils/testDefaults.ts
@@ -8,6 +8,7 @@ import {
     Comment,
     Attachment,
     Duration,
+    Deadline,
 } from '../types'
 
 const DEFAULT_TASK_ID = '1234'
@@ -43,6 +44,8 @@ export const DEFAULT_DUE_DATE = {
     isRecurring: false,
     string: 'a date string',
     date: DEFAULT_DATE,
+    lang: 'en',
+    timezone: null,
 }
 
 export const DEFAULT_DURATION: Duration = {
@@ -50,9 +53,9 @@ export const DEFAULT_DURATION: Duration = {
     unit: 'minute',
 }
 
-export const INVALID_DUE_DATE = {
-    ...DEFAULT_DUE_DATE,
-    isRecurring: 'false',
+export const DEFAULT_DEADLINE: Deadline = {
+    date: '2020-09-08',
+    lang: 'en',
 }
 
 export const DEFAULT_QUICK_ADD_RESPONSE: QuickAddTaskResponse = {
@@ -77,6 +80,8 @@ export const DEFAULT_QUICK_ADD_RESPONSE: QuickAddTaskResponse = {
         lang: 'en',
         isRecurring: false,
     },
+    deadline: DEFAULT_DEADLINE,
+    assignedByUid: DEFAULT_CREATOR,
 }
 
 export const DEFAULT_TASK: Task = {
@@ -94,14 +99,16 @@ export const DEFAULT_TASK: Task = {
     createdAt: DEFAULT_DATE,
     url: 'https://todoist.com/showTask?id=1234',
     due: DEFAULT_DUE_DATE,
+    assignerId: DEFAULT_CREATOR,
     assigneeId: DEFAULT_ASSIGNEE,
     creatorId: DEFAULT_CREATOR,
     duration: DEFAULT_DURATION,
+    deadline: DEFAULT_DEADLINE,
 }
 
 export const INVALID_TASK = {
     ...DEFAULT_TASK,
-    due: INVALID_DUE_DATE,
+    due: '2020-01-31',
 }
 
 export const TASK_WITH_OPTIONALS_AS_NULL: Task = {
@@ -190,6 +197,7 @@ export const INVALID_ATTACHMENT = {
 export const DEFAULT_COMMENT: Comment = {
     id: DEFAULT_COMMENT_ID,
     content: DEFAULT_COMMENT_CONTENT,
+    taskId: null,
     projectId: DEFAULT_PROJECT_ID,
     attachment: DEFAULT_ATTACHMENT,
     postedAt: DEFAULT_DATE,

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -48,54 +48,56 @@ export const Duration = Record({
 
 export type Duration = Static<typeof Duration>
 
+export const Deadline = Record({
+    date: String,
+    lang: String,
+})
+
+export type Deadline = Static<typeof Deadline>
+
 export const Task = Record({
     id: String,
+    assignerId: String.Or(Null),
+    assigneeId: String.Or(Null),
+    projectId: String,
+    sectionId: String.Or(Null),
+    parentId: String.Or(Null),
     order: Int,
     content: String,
     description: String,
-    projectId: String,
     isCompleted: Boolean,
     labels: Array(String),
     priority: Int,
     commentCount: Int,
-    createdAt: String,
-    url: String,
     creatorId: String,
-}).And(
-    Partial({
-        due: DueDate.Or(Null),
-        duration: Duration.Or(Null),
-        assigneeId: String.Or(Null),
-        assignerId: String.Or(Null),
-        parentId: String.Or(Null),
-        sectionId: String.Or(Null),
-    }),
-)
+    createdAt: String,
+    due: DueDate.Or(Null),
+    url: String,
+    duration: Duration.Or(Null),
+    deadline: Deadline.Or(Null),
+})
 
 export type Task = Static<typeof Task>
 
 export const Project = Record({
     id: String,
-    name: String,
+    parentId: String.Or(Null),
+    order: Int.Or(Null),
     color: String,
+    name: String,
     commentCount: Int,
     isShared: Boolean,
     isFavorite: Boolean,
-    url: String,
     isInboxProject: Boolean,
     isTeamInbox: Boolean,
-    order: Int,
+    url: String,
     viewStyle: String,
-}).And(
-    Partial({
-        parentId: String.Or(Null),
-    }),
-)
+})
 
 export type Project = Static<typeof Project>
 
 // This allows us to accept any string during validation, but provide intellisense for the two possible values in request args
-export type ProjectViewStyle = 'list' | 'board'
+export type ProjectViewStyle = 'list' | 'board' | 'calendar'
 
 export const Section = Record({
     id: String,
@@ -108,7 +110,7 @@ export type Section = Static<typeof Section>
 
 export const Label = Record({
     id: String,
-    order: Int,
+    order: Int.Or(Null),
     name: String,
     color: String,
     isFavorite: Boolean,
@@ -138,15 +140,12 @@ export type Attachment = Static<typeof Attachment>
 
 export const Comment = Record({
     id: String,
+    taskId: String.Or(Null),
+    projectId: String.Or(Null),
     content: String,
     postedAt: String,
-}).And(
-    Partial({
-        taskId: String.Or(Null),
-        projectId: String.Or(Null),
-        attachment: Attachment.Or(Null),
-    }),
-)
+    attachment: Attachment.Or(Null),
+})
 
 export type Comment = Static<typeof Comment>
 
@@ -195,16 +194,12 @@ export type QuickAddTaskResponse = {
     parentId: string | null
     childOrder: number // order
     labels: string[]
+    assignedByUid: string | null
     responsibleUid: string | null
     checked: boolean // completed
     addedAt: string // created
     addedByUid: string | null
     duration: Duration | null
-    due: {
-        date: string
-        timezone: string | null
-        isRecurring: boolean
-        string: string
-        lang: string
-    } | null
+    due: DueDate | null
+    deadline: Deadline | null
 }

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -10,9 +10,11 @@ export type AddTaskArgs = {
     order?: number
     labels?: string[]
     priority?: number
-    dueLang?: string
     assigneeId?: string
     dueString?: string
+    dueLang?: string
+    deadlineLang?: string
+    deadlineDate?: string
 } & RequireOneOrNone<{
     dueDate?: string
     dueDatetime?: string
@@ -27,6 +29,7 @@ export type QuickAddTaskArgs = {
     note?: string
     reminder?: string
     autoReminder?: boolean
+    meta?: boolean
 }
 
 export type GetTasksArgs = {
@@ -36,6 +39,8 @@ export type GetTasksArgs = {
     filter?: string
     lang?: string
     ids?: string[]
+    cursor?: string | null
+    limit?: number
 }
 
 export type UpdateTaskArgs = {
@@ -43,9 +48,11 @@ export type UpdateTaskArgs = {
     description?: string
     labels?: string[]
     priority?: number
+    dueString?: string
     dueLang?: string | null
     assigneeId?: string | null
-    dueString?: string
+    deadlineDate?: string | null
+    deadlineLang?: string | null
 } & RequireOneOrNone<{
     dueDate?: string
     dueDatetime?: string
@@ -55,10 +62,15 @@ export type UpdateTaskArgs = {
         durationUnit?: Duration['unit']
     }>
 
+export type GetProjectsArgs = {
+    cursor?: string | null
+    limit?: number
+}
+
 export type AddProjectArgs = {
     name: string
     parentId?: string
-    color?: string
+    color?: string | number
     isFavorite?: boolean
     viewStyle?: ProjectViewStyle
 }
@@ -70,36 +82,57 @@ export type UpdateProjectArgs = {
     viewStyle?: ProjectViewStyle
 }
 
+export type GetProjectCollaboratorsArgs = {
+    cursor?: string | null
+    limit?: number
+}
+
+export type GetSections = {
+    projectId: string | null
+    cursor?: string | null
+    limit?: number
+}
+
 export type AddSectionArgs = {
     name: string
     projectId: string
-    order?: number
+    order?: number | null
 }
 
 export type UpdateSectionArgs = {
     name: string
 }
 
+export type GetLabelsArgs = {
+    cursor?: string | null
+    limit?: number
+}
+
 export type AddLabelArgs = {
     name: string
-    order?: number
-    color?: string
+    order?: number | null
+    color?: string | number
     isFavorite?: boolean
 }
 
 export type UpdateLabelArgs = {
     name?: string
-    order?: number
+    order?: number | null
     color?: string
     isFavorite?: boolean
 }
 
-export type GetTaskCommentsArgs = {
+export type GetCommentsBaseArgs = {
+    cursor?: string | null
+    limit?: number
+}
+
+export type GetTaskCommentsArgs = GetCommentsBaseArgs & {
     taskId: string
     projectId?: never
 }
 
-export type GetProjectCommentsArgs = {
+export type GetProjectCommentsArgs = GetCommentsBaseArgs & {
     projectId: string
     taskId?: never
 }
@@ -111,7 +144,7 @@ export type AddCommentArgs = {
         fileUrl: string
         fileType?: string
         resourceType?: string
-    }
+    } | null
 } & RequireExactlyOne<{
     taskId?: string
     projectId?: string
@@ -123,6 +156,8 @@ export type UpdateCommentArgs = {
 
 export type GetSharedLabelsArgs = {
     omitPersonal?: boolean
+    cursor?: string | null
+    limit?: number
 }
 
 export type RenameSharedLabelArgs = {

--- a/src/utils/taskConverters.test.ts
+++ b/src/utils/taskConverters.test.ts
@@ -7,33 +7,6 @@ describe('getTaskFromQuickAddResponse', () => {
         expect(task).toEqual({ ...DEFAULT_TASK, labels: ['personal', 'work', 'hobby'] })
     })
 
-    test('converts null sectionId to null', () => {
-        const quickAddResponse = {
-            ...DEFAULT_QUICK_ADD_RESPONSE,
-            sectionId: null,
-        }
-        const task = getTaskFromQuickAddResponse(quickAddResponse)
-        expect(task.sectionId).toEqual(undefined)
-    })
-
-    test('converts null parentId to undefined', () => {
-        const quickAddResponse = {
-            ...DEFAULT_QUICK_ADD_RESPONSE,
-            parentId: null,
-        }
-        const task = getTaskFromQuickAddResponse(quickAddResponse)
-        expect(task.parentId).toEqual(undefined)
-    })
-
-    test('converts null assigneeId to undefined', () => {
-        const quickAddResponse = {
-            ...DEFAULT_QUICK_ADD_RESPONSE,
-            responsibleUid: null,
-        }
-        const task = getTaskFromQuickAddResponse(quickAddResponse)
-        expect(task.assigneeId).toEqual(undefined)
-    })
-
     const completedTheories = [
         [false, false],
         [true, true],
@@ -51,15 +24,6 @@ describe('getTaskFromQuickAddResponse', () => {
             expect(task.isCompleted).toEqual(completedBoolean)
         },
     )
-
-    test('converts null due date to undefined', () => {
-        const quickAddResponse = {
-            ...DEFAULT_QUICK_ADD_RESPONSE,
-            due: null,
-        }
-        const task = getTaskFromQuickAddResponse(quickAddResponse)
-        expect(task.due).toEqual(undefined)
-    })
 
     const taskUrlTheories = [
         ['1234', 'https://todoist.com/showTask?id=1234'],

--- a/src/utils/taskConverters.ts
+++ b/src/utils/taskConverters.ts
@@ -7,23 +7,13 @@ function getTaskUrlFromQuickAddResponse(responseData: QuickAddTaskResponse) {
 }
 
 export function getTaskFromQuickAddResponse(responseData: QuickAddTaskResponse): Task {
-    const due = responseData.due
-        ? {
-              isRecurring: responseData.due.isRecurring,
-              string: responseData.due.string,
-              date: responseData.due.date,
-              ...(responseData.due.timezone !== null && { datetime: responseData.due.date }),
-              ...(responseData.due.timezone !== null && { timezone: responseData.due.timezone }),
-          }
-        : undefined
-
     const task = {
         id: responseData.id,
         order: responseData.childOrder,
         content: responseData.content,
         description: responseData.description,
         projectId: responseData.projectId,
-        sectionId: responseData.sectionId ? responseData.sectionId : undefined,
+        sectionId: responseData.sectionId,
         isCompleted: responseData.checked,
         labels: responseData.labels,
         priority: responseData.priority,
@@ -31,12 +21,12 @@ export function getTaskFromQuickAddResponse(responseData: QuickAddTaskResponse):
         createdAt: responseData.addedAt,
         url: getTaskUrlFromQuickAddResponse(responseData),
         creatorId: responseData.addedByUid ?? '',
-        ...(due !== undefined && { due }),
-        ...(responseData.parentId !== null && { parentId: responseData.parentId }),
-        ...(responseData.responsibleUid !== null && {
-            assigneeId: responseData.responsibleUid,
-        }),
+        parentId: responseData.parentId,
         duration: responseData.duration,
+        assignerId: responseData.assignedByUid,
+        assigneeId: responseData.responsibleUid,
+        deadline: responseData.deadline,
+        due: responseData.due,
     }
 
     return task


### PR DESCRIPTION
<!-- Remember to use semantic PR titles: https://handbook.doist.com/doc/semantic-pr-titles-EoD3Udnow0 -->
<!-- Make sure to follow the guidelines: https://handbook.doist.com/doc/collaboration-aBwi8RJIEJ -->

<!--
    📝 Is this a user-facing change?
    - Add the `@external-change` label to this PR
    - Write your change in between `USER_FACING_CHANGELOG_ENTRY` delimiters
    - Keep the delimiters in place!!
    - Here are some guidelines on how to write great changelog entries:
        https://docs.google.com/document/d/15ab9oDmIGyqhLoicsGkYvFwUIHRRlrP_yJsLFh3uUV8
-->

<!--
Ship/Show/Ask: https://handbook.doist.com/doc/peer-review-guidelines-rtOvsilzRh#h-ship-show-ask
- `⛴ Ship PR`: Non-functional changes, tiny bug fixes, or tiny documentation improvements
- `👀 Show PR`: Tiny changes, small refactors, small configuration/tooling changes, updating documentation, knowledge sharing (e.g., for Ship PRs), or applying changes agreed in merged PRs
- `🙋 Ask PR`: Everything else
-->

## 🗺 Overview

<!-- Brief description of the implementation and its trade-offs -->

In line with ongoing internal efforts, this PR refactors the SDK to serve as an intermediary between consumers and the [Todoist Sync API](https://developer.todoist.com/sync/v9/#overview), replacing the [Todoist REST API](https://developer.todoist.com/rest/v2/#overview).

### **Changes in this Refactor:**

The SDK API remains largely unchanged, with the following exceptions:
  - Some new properties have been added to entities.
  - Certain existing properties have been marked as required.
  - The following methods are now **paginated**:

    ```plaintext
    - getTasks
    - getProjects
    - getProjectCollaborators
    - getSections
    - getLabels
    - getSharedLabels
    - getComments
    ```

This refactor ensures compatibility with the latest version of the Todoist Sync API while maintaining the familiar client API interface for consumers.

### **Caveats:**

  - Passing the `ids` argument to the `getTasks` method only works with **v1 IDs**.
  - Updating a comment via `updateComment` only works with **v1 IDs**.
  - `delete*` methods throw an error due to CORS restrictions (the respective Sync API endpoints `Access-Control-Allow-Methods` response header only allows `GET, POST`).
 - Creating a section with `addSection` only works if the project ID is a **v1 ID**.
- Updating a section via `updateSection` only works with **v1 IDs**.


### **Release:**

This PR will be merged into the `v4` branch, from which several pre-release versions will be created until a stable v4 release.