### PR TITLE
fix: map updated API task and project objects to match local schemas

### DIFF
--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -2,9 +2,9 @@ import { TodoistApi } from '.'
 import {
     DEFAULT_AUTH_TOKEN,
     DEFAULT_PROJECT,
+    RAW_DEFAULT_PROJECT,
     DEFAULT_REQUEST_ID,
     DEFAULT_USER,
-    PROJECT_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
     getSyncBaseUri,
@@ -21,7 +21,7 @@ describe('TodoistApi project endpoints', () => {
     describe('getProject', () => {
         test('calls get request with expected url', async () => {
             const projectId = '12'
-            const requestMock = setupRestClientMock(DEFAULT_PROJECT)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_PROJECT)
             const api = getTarget()
 
             await api.getProject(projectId)
@@ -36,7 +36,7 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock(DEFAULT_PROJECT)
+            setupRestClientMock(RAW_DEFAULT_PROJECT)
             const api = getTarget()
 
             const project = await api.getProject('123')
@@ -48,7 +48,7 @@ describe('TodoistApi project endpoints', () => {
     describe('getProjects', () => {
         test('calls get on projects endpoint', async () => {
             const requestMock = setupRestClientMock({
-                results: [DEFAULT_PROJECT],
+                results: [RAW_DEFAULT_PROJECT],
                 nextCursor: '123',
             })
             const api = getTarget()
@@ -67,13 +67,13 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            const projects = [DEFAULT_PROJECT, PROJECT_WITH_OPTIONALS_AS_NULL]
+            const projects = [RAW_DEFAULT_PROJECT]
             setupRestClientMock({ results: projects, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getProjects()
 
-            expect(results).toEqual(projects)
+            expect(results).toEqual([DEFAULT_PROJECT])
             expect(nextCursor).toBe('123')
         })
     })
@@ -84,7 +84,7 @@ describe('TodoistApi project endpoints', () => {
         }
 
         test('calls post on restClient with expected parameters', async () => {
-            const requestMock = setupRestClientMock(DEFAULT_PROJECT)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_PROJECT)
             const api = getTarget()
 
             await api.addProject(DEFAULT_ADD_PROJECT_ARGS, DEFAULT_REQUEST_ID)
@@ -101,7 +101,7 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock(DEFAULT_PROJECT)
+            setupRestClientMock(RAW_DEFAULT_PROJECT)
             const api = getTarget()
 
             const project = await api.addProject(DEFAULT_ADD_PROJECT_ARGS)
@@ -115,7 +115,7 @@ describe('TodoistApi project endpoints', () => {
         test('calls post on restClient with expected parameters', async () => {
             const projectId = '123'
             const updateArgs = { name: 'a new name' }
-            const requestMock = setupRestClientMock(DEFAULT_PROJECT, 204)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_PROJECT, 204)
             const api = getTarget()
 
             await api.updateProject(projectId, updateArgs, DEFAULT_REQUEST_ID)
@@ -132,13 +132,20 @@ describe('TodoistApi project endpoints', () => {
         })
 
         test('returns success result from rest client', async () => {
-            const returnedProject = { ...DEFAULT_PROJECT, ...DEFAULT_UPDATE_PROJECT_ARGS }
-            setupRestClientMock(returnedProject, 204)
+            const RAW_DEFAULT_PROJECT_WITH_UPDATES = {
+                ...RAW_DEFAULT_PROJECT,
+                name: DEFAULT_UPDATE_PROJECT_ARGS.name,
+            }
+            setupRestClientMock(RAW_DEFAULT_PROJECT_WITH_UPDATES, 204)
             const api = getTarget()
 
             const result = await api.updateProject('123', DEFAULT_UPDATE_PROJECT_ARGS)
 
-            expect(result).toEqual(returnedProject)
+            const DEFAULT_PROJECT_WITH_UPDATES = {
+                ...DEFAULT_PROJECT,
+                name: DEFAULT_UPDATE_PROJECT_ARGS.name,
+            }
+            expect(result).toEqual(DEFAULT_PROJECT_WITH_UPDATES)
         })
     })
 

--- a/src/TodoistApi.tasks.test.ts
+++ b/src/TodoistApi.tasks.test.ts
@@ -6,6 +6,7 @@ import {
     DEFAULT_QUICK_ADD_RESPONSE,
     DEFAULT_REQUEST_ID,
     DEFAULT_TASK,
+    RAW_DEFAULT_TASK,
     TASK_WITH_OPTIONALS_AS_NULL,
 } from './testUtils/testDefaults'
 import {
@@ -33,7 +34,7 @@ describe('TodoistApi task endpoints', () => {
         }
 
         test('calls post on restClient with expected parameters', async () => {
-            const requestMock = setupRestClientMock(DEFAULT_TASK)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_TASK)
             const api = getTarget()
 
             await api.addTask(DEFAULT_ADD_TASK_ARGS, DEFAULT_REQUEST_ID)
@@ -50,7 +51,7 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('calls post on restClient with expected parameters against staging', async () => {
-            const requestMock = setupRestClientMock(DEFAULT_TASK)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_TASK)
             const api = getTarget('https://staging.todoist.com')
 
             await api.addTask(DEFAULT_ADD_TASK_ARGS, DEFAULT_REQUEST_ID)
@@ -67,7 +68,7 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock(DEFAULT_TASK)
+            setupRestClientMock(RAW_DEFAULT_TASK)
             const api = getTarget()
 
             const task = await api.addTask(DEFAULT_ADD_TASK_ARGS)
@@ -81,7 +82,7 @@ describe('TodoistApi task endpoints', () => {
 
         test('calls post on restClient with expected parameters', async () => {
             const taskId = '123'
-            const requestMock = setupRestClientMock(DEFAULT_TASK, 204)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_TASK, 204)
             const api = getTarget()
 
             await api.updateTask(taskId, DEFAULT_UPDATE_TASK_ARGS, DEFAULT_REQUEST_ID)
@@ -98,13 +99,20 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('returns success result from rest client', async () => {
-            const returnedTask = { ...DEFAULT_TASK, ...DEFAULT_UPDATE_TASK_ARGS }
-            setupRestClientMock(returnedTask, 204)
+            const RAW_DEFAULT_TASK_WITH_UPDATES = {
+                ...RAW_DEFAULT_TASK,
+                content: DEFAULT_UPDATE_TASK_ARGS.content,
+            }
+            setupRestClientMock(RAW_DEFAULT_TASK_WITH_UPDATES, 204)
             const api = getTarget()
 
             const response = await api.updateTask('123', DEFAULT_UPDATE_TASK_ARGS)
 
-            expect(response).toEqual(returnedTask)
+            const DEFAULT_TASK_WITH_UPDATES = {
+                ...DEFAULT_TASK,
+                content: DEFAULT_UPDATE_TASK_ARGS.content,
+            }
+            expect(response).toEqual(DEFAULT_TASK_WITH_UPDATES)
         })
     })
 
@@ -235,7 +243,7 @@ describe('TodoistApi task endpoints', () => {
     describe('getTask', () => {
         test('calls get request with expected url', async () => {
             const taskId = '12'
-            const requestMock = setupRestClientMock(DEFAULT_TASK)
+            const requestMock = setupRestClientMock(RAW_DEFAULT_TASK)
             const api = getTarget()
 
             await api.getTask(taskId)
@@ -259,7 +267,7 @@ describe('TodoistApi task endpoints', () => {
 
         test('calls get on expected endpoint with args', async () => {
             const requestMock = setupRestClientMock({
-                results: [DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL],
+                results: [RAW_DEFAULT_TASK, TASK_WITH_OPTIONALS_AS_NULL],
                 nextCursor: '123',
             })
             const api = getTarget()
@@ -277,13 +285,13 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            const tasks = [DEFAULT_TASK]
+            const tasks = [RAW_DEFAULT_TASK]
             setupRestClientMock({ results: tasks, nextCursor: '123' })
             const api = getTarget()
 
             const { results, nextCursor } = await api.getTasks(DEFAULT_GET_TASKS_ARGS)
 
-            expect(results).toEqual(tasks)
+            expect(results).toEqual([DEFAULT_TASK])
             expect(nextCursor).toBe('123')
         })
     })
@@ -297,7 +305,10 @@ describe('TodoistApi task endpoints', () => {
         }
 
         test('calls get request with expected url', async () => {
-            const requestMock = setupRestClientMock({ results: [DEFAULT_TASK], nextCursor: null })
+            const requestMock = setupRestClientMock({
+                results: [RAW_DEFAULT_TASK],
+                nextCursor: null,
+            })
             const api = getTarget()
 
             await api.getTasksByFilter(DEFAULT_GET_TASKS_BY_FILTER_ARGS)
@@ -313,7 +324,7 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('returns result from rest client', async () => {
-            setupRestClientMock({ results: [DEFAULT_TASK], nextCursor: null })
+            setupRestClientMock({ results: [RAW_DEFAULT_TASK], nextCursor: null })
             const api = getTarget()
 
             const response = await api.getTasksByFilter(DEFAULT_GET_TASKS_BY_FILTER_ARGS)
@@ -325,7 +336,7 @@ describe('TodoistApi task endpoints', () => {
         })
 
         test('validates task array in response', async () => {
-            const invalidTask = { ...DEFAULT_TASK, due: '2020-01-31' }
+            const invalidTask = { ...RAW_DEFAULT_TASK, due: '2020-01-31' }
             setupRestClientMock({ results: [invalidTask], nextCursor: null })
             const api = getTarget()
 

--- a/src/testUtils/testDefaults.ts
+++ b/src/testUtils/testDefaults.ts
@@ -9,6 +9,8 @@ import {
     Attachment,
     Duration,
     Deadline,
+    RawTask,
+    RawProject,
 } from '../types'
 
 const DEFAULT_TASK_ID = '1234'
@@ -111,14 +113,30 @@ export const INVALID_TASK = {
     due: '2020-01-31',
 }
 
-export const TASK_WITH_OPTIONALS_AS_NULL: Task = {
-    ...DEFAULT_TASK,
-    due: null,
-    assigneeId: null,
-    assignerId: null,
-    parentId: null,
+export const TASK_WITH_OPTIONALS_AS_NULL: RawTask = {
+    userId: DEFAULT_CREATOR,
+    id: DEFAULT_TASK_ID,
+    projectId: DEFAULT_PROJECT_ID,
     sectionId: null,
+    parentId: null,
+    addedByUid: DEFAULT_CREATOR,
+    assignedByUid: null,
+    responsibleUid: null,
+    labels: [],
+    deadline: null,
     duration: null,
+    checked: false,
+    isDeleted: false,
+    addedAt: DEFAULT_DATE,
+    completedAt: null,
+    updatedAt: DEFAULT_DATE,
+    due: null,
+    priority: DEFAULT_TASK_PRIORITY,
+    childOrder: DEFAULT_ORDER,
+    content: DEFAULT_TASK_CONTENT,
+    description: DEFAULT_TASK_DESCRIPTION,
+    dayOrder: DEFAULT_ORDER,
+    isCollapsed: false,
 }
 
 export const DEFAULT_PROJECT: Project = {
@@ -268,4 +286,52 @@ export const RAW_COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT: RawComment = {
 export const COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT = {
     ...RAW_COMMENT_WITH_OPTIONALS_AS_NULL_PROJECT,
     taskId: undefined,
+}
+
+export const RAW_DEFAULT_TASK: RawTask = {
+    userId: DEFAULT_CREATOR,
+    id: DEFAULT_TASK_ID,
+    projectId: DEFAULT_PROJECT_ID,
+    sectionId: DEFAULT_SECTION_ID,
+    parentId: DEFAULT_PARENT_ID,
+    addedByUid: DEFAULT_CREATOR,
+    assignedByUid: DEFAULT_CREATOR,
+    responsibleUid: DEFAULT_ASSIGNEE,
+    labels: DEFAULT_LABELS,
+    deadline: DEFAULT_DEADLINE,
+    duration: DEFAULT_DURATION,
+    checked: false,
+    isDeleted: false,
+    addedAt: DEFAULT_DATE,
+    completedAt: null,
+    updatedAt: DEFAULT_DATE,
+    due: DEFAULT_DUE_DATE,
+    priority: DEFAULT_TASK_PRIORITY,
+    childOrder: DEFAULT_ORDER,
+    content: DEFAULT_TASK_CONTENT,
+    description: DEFAULT_TASK_DESCRIPTION,
+    dayOrder: DEFAULT_ORDER,
+    isCollapsed: false,
+}
+
+export const RAW_DEFAULT_PROJECT: RawProject = {
+    id: DEFAULT_PROJECT_ID,
+    canAssignTasks: true,
+    childOrder: DEFAULT_ORDER,
+    color: DEFAULT_ENTITY_COLOR,
+    createdAt: DEFAULT_DATE,
+    isArchived: false,
+    isDeleted: false,
+    isFavorite: false,
+    isFrozen: false,
+    name: DEFAULT_PROJECT_NAME,
+    updatedAt: DEFAULT_DATE,
+    viewStyle: DEFAULT_PROJECT_VIEW_STYLE,
+    defaultOrder: DEFAULT_ORDER,
+    description: '',
+    publicAccess: false,
+    parentId: DEFAULT_PROJECT_ID,
+    inboxProject: false,
+    isCollapsed: false,
+    isShared: false,
 }

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -36,6 +36,34 @@ export const DeadlineSchema = z.object({
  */
 export interface Deadline extends z.infer<typeof DeadlineSchema> {}
 
+export const RawTaskSchema = z.object({
+    userId: z.string(),
+    id: z.string(),
+    projectId: z.string(),
+    sectionId: z.string().nullable(),
+    parentId: z.string().nullable(),
+    addedByUid: z.string(),
+    assignedByUid: z.string().nullable(),
+    responsibleUid: z.string().nullable(),
+    labels: z.array(z.string()),
+    deadline: DeadlineSchema.nullable(),
+    duration: DurationSchema.nullable(),
+    checked: z.boolean(),
+    isDeleted: z.boolean(),
+    addedAt: z.string(),
+    completedAt: z.string().nullable(),
+    updatedAt: z.string(),
+    due: DueDateSchema.nullable(),
+    priority: z.number().int(),
+    childOrder: z.number().int(),
+    content: z.string(),
+    description: z.string(),
+    dayOrder: z.number().int(),
+    isCollapsed: z.boolean(),
+})
+
+export interface RawTask extends z.infer<typeof RawTaskSchema> {}
+
 export const TaskSchema = z.object({
     id: z.string(),
     assignerId: z.string().nullable(),
@@ -62,7 +90,7 @@ export const TaskSchema = z.object({
  */
 export interface Task extends z.infer<typeof TaskSchema> {}
 
-export const ProjectSchema = z.object({
+export const RawProjectSchema = z.object({
     id: z.string(),
     canAssignTasks: z.boolean(),
     childOrder: z.number().int().nullable(),
@@ -82,6 +110,21 @@ export const ProjectSchema = z.object({
     inboxProject: z.boolean(),
     isCollapsed: z.boolean(),
     isShared: z.boolean(),
+})
+export interface RawProject extends z.infer<typeof RawProjectSchema> {}
+
+export const ProjectSchema = z.object({
+    id: z.string(),
+    parentId: z.string().nullable(),
+    order: z.number().int().nullable(),
+    color: z.string(),
+    name: z.string(),
+    isShared: z.boolean(),
+    isFavorite: z.boolean(),
+    isInboxProject: z.boolean(),
+    isTeamInbox: z.boolean(),
+    url: z.string(),
+    viewStyle: z.string(),
 })
 /**
  * Represents a project in Todoist.

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -106,8 +106,8 @@ export const RawProjectSchema = z.object({
     defaultOrder: z.number().int().nullable(),
     description: z.string(),
     publicAccess: z.boolean(),
-    parentId: z.string().nullable(),
-    inboxProject: z.boolean(),
+    parentId: z.string().nullable().optional(),
+    inboxProject: z.boolean().optional(),
     isCollapsed: z.boolean(),
     isShared: z.boolean(),
 })

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -64,16 +64,24 @@ export interface Task extends z.infer<typeof TaskSchema> {}
 
 export const ProjectSchema = z.object({
     id: z.string(),
-    parentId: z.string().nullable(),
-    order: z.number().int().nullable(),
+    canAssignTasks: z.boolean(),
+    childOrder: z.number().int().nullable(),
     color: z.string(),
-    name: z.string(),
-    isShared: z.boolean(),
+    createdAt: z.string(),
+    isArchived: z.boolean(),
+    isDeleted: z.boolean(),
     isFavorite: z.boolean(),
-    isInboxProject: z.boolean(),
-    isTeamInbox: z.boolean(),
-    url: z.string(),
+    isFrozen: z.boolean(),
+    name: z.string(),
+    updatedAt: z.string(),
     viewStyle: z.string(),
+    defaultOrder: z.number().int().nullable(),
+    description: z.string(),
+    publicAccess: z.boolean(),
+    parentId: z.string().nullable(),
+    inboxProject: z.boolean(),
+    isCollapsed: z.boolean(),
+    isShared: z.boolean(),
 })
 /**
  * Represents a project in Todoist.

--- a/src/utils/projectConverter.ts
+++ b/src/utils/projectConverter.ts
@@ -8,14 +8,14 @@ function getProjectUrlFromProjectId(projectId: string) {
 export function getProjectFromRawProjectResponse(responseData: RawProject): Project {
     const project = {
         id: responseData.id,
-        parentId: responseData.parentId,
+        parentId: responseData.parentId ?? null, // workspace projects do not have a parent
         order: responseData.childOrder,
         color: responseData.color,
         name: responseData.name,
         isShared: responseData.isShared,
         isFavorite: responseData.isFavorite,
-        isInboxProject: responseData.inboxProject,
-        isTeamInbox: responseData.inboxProject && responseData.isShared, // just guessing
+        isInboxProject: responseData.inboxProject ?? false, // workspace projects do not set this flag
+        isTeamInbox: false, // this flag is no longer used
         url: getProjectUrlFromProjectId(responseData.id),
         viewStyle: responseData.viewStyle,
     }

--- a/src/utils/projectConverter.ts
+++ b/src/utils/projectConverter.ts
@@ -1,0 +1,23 @@
+import { Project, RawProject } from '../types'
+
+const showProjectEndpoint = 'https://todoist.com/showProject'
+
+function getProjectUrlFromProjectId(projectId: string) {
+    return `${showProjectEndpoint}?id=${projectId}`
+}
+export function getProjectFromRawProjectResponse(responseData: RawProject): Project {
+    const project = {
+        id: responseData.id,
+        parentId: responseData.parentId,
+        order: responseData.childOrder,
+        color: responseData.color,
+        name: responseData.name,
+        isShared: responseData.isShared,
+        isFavorite: responseData.isFavorite,
+        isInboxProject: responseData.inboxProject,
+        isTeamInbox: responseData.inboxProject && responseData.isShared, // just guessing
+        url: getProjectUrlFromProjectId(responseData.id),
+        viewStyle: responseData.viewStyle,
+    }
+    return project
+}

--- a/src/utils/taskConverters.ts
+++ b/src/utils/taskConverters.ts
@@ -1,9 +1,9 @@
-import { QuickAddTaskResponse, Task } from '../types'
+import { QuickAddTaskResponse, RawTask, Task } from '../types'
 
 const showTaskEndpoint = 'https://todoist.com/showTask'
 
-function getTaskUrlFromQuickAddResponse(responseData: QuickAddTaskResponse) {
-    return `${showTaskEndpoint}?id=${responseData.id}`
+function getTaskUrlFromTaskId(taskId: string) {
+    return `${showTaskEndpoint}?id=${taskId}`
 }
 
 export function getTaskFromQuickAddResponse(responseData: QuickAddTaskResponse): Task {
@@ -18,7 +18,7 @@ export function getTaskFromQuickAddResponse(responseData: QuickAddTaskResponse):
         labels: responseData.labels,
         priority: responseData.priority,
         createdAt: responseData.addedAt,
-        url: getTaskUrlFromQuickAddResponse(responseData),
+        url: getTaskUrlFromTaskId(responseData.id),
         creatorId: responseData.addedByUid ?? '',
         parentId: responseData.parentId,
         duration: responseData.duration,
@@ -28,5 +28,29 @@ export function getTaskFromQuickAddResponse(responseData: QuickAddTaskResponse):
         due: responseData.due,
     }
 
+    return task
+}
+
+export function getTaskFromRawTaskResponse(responseData: RawTask): Task {
+    const task = {
+        id: responseData.id,
+        assignerId: responseData.assignedByUid,
+        assigneeId: responseData.responsibleUid,
+        projectId: responseData.projectId,
+        sectionId: responseData.sectionId,
+        parentId: responseData.parentId,
+        order: responseData.childOrder,
+        content: responseData.content,
+        description: responseData.description,
+        isCompleted: responseData.checked,
+        labels: responseData.labels,
+        priority: responseData.priority,
+        creatorId: responseData.addedByUid,
+        createdAt: responseData.addedAt,
+        due: responseData.due,
+        url: getTaskUrlFromTaskId(responseData.id),
+        duration: responseData.duration,
+        deadline: responseData.deadline,
+    }
     return task
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,6 +1,4 @@
 import {
-    TaskSchema,
-    ProjectSchema,
     SectionSchema,
     LabelSchema,
     CommentSchema,
@@ -11,9 +9,20 @@ import {
     type Label,
     type Comment,
     type User,
+    RawTaskSchema,
+    RawProjectSchema,
+    ProjectSchema,
+    TaskSchema,
 } from '../types/entities'
+import { getProjectFromRawProjectResponse } from './projectConverter'
+import { getTaskFromRawTaskResponse } from './taskConverters'
 
 export function validateTask(input: unknown): Task {
+    const rawTaskParse = RawTaskSchema.safeParse(input)
+    if (rawTaskParse.success) {
+        const task = getTaskFromRawTaskResponse(rawTaskParse.data)
+        return task
+    }
     return TaskSchema.parse(input)
 }
 
@@ -22,6 +31,11 @@ export function validateTaskArray(input: unknown[]): Task[] {
 }
 
 export function validateProject(input: unknown): Project {
+    const rawProjectParse = RawProjectSchema.safeParse(input)
+    if (rawProjectParse.success) {
+        const project = getProjectFromRawProjectResponse(rawProjectParse.data)
+        return project
+    }
     return ProjectSchema.parse(input)
 }
 


### PR DESCRIPTION
This schema def fixes the issue I encountered when using GetProjects and better matches the API docs for the [project response](https://todoist.com/api/v1/docs#tag/Projects/operation/get_projects_api_v1_projects_get)

This change makes tests in the repository fail.

Task entity also needs to be aligned

Maybe the typing needs to be adjusted. Only tested that it no longer threw Zod Errors.