### PR TITLE
chore: Adds the `backups:read` scope

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -19,6 +19,7 @@ export type Permission =
     | 'data:read_write'
     | 'data:delete'
     | 'project:delete'
+    | 'backups:read'
 
 /**
  * Parameters required to exchange an authorization code for an access token.

--- a/website/docs/authorization.md
+++ b/website/docs/authorization.md
@@ -63,5 +63,6 @@ const task = await api.addTask({
 -   `data:read_write` - Read and write access
 -   `data:delete` - Full access including delete
 -   `project:delete` - Can delete projects
+-   `backups:read` - Can read the user's list of backups without MFA
 
 📖 For detailed implementation steps and security considerations, consult the [Todoist API v1 Authorization Guide](https://todoist.com/api/v1/docs#tag/Authorization).


### PR DESCRIPTION
Adding the new `backups:read` scope as one of the authorisation scopes. This scope allows developers to fetch the list of user's backups and bypass the MFA checks. 