### PR TITLE
chore: Ensures that `creatorId` is not null

### DIFF
--- a/src/utils/taskConverters.ts
+++ b/src/utils/taskConverters.ts
@@ -45,7 +45,7 @@ export function getTaskFromRawTaskResponse(responseData: RawTask): Task {
         isCompleted: responseData.checked,
         labels: responseData.labels,
         priority: responseData.priority,
-        creatorId: responseData.addedByUid,
+        creatorId: responseData.addedByUid ?? '',
         createdAt: responseData.addedAt,
         due: responseData.due,
         url: getTaskUrlFromTaskId(responseData.id),


### PR DESCRIPTION
Fixes https://github.com/Doist/todoist-api-typescript/issues/290

Ensures that the creatorId field is not null.