### PR TITLE
chore: Do not serialise null/undefined values for GET calls

### DIFF
--- a/src/restClient.axios.test.ts
+++ b/src/restClient.axios.test.ts
@@ -17,4 +17,32 @@ describe('axios tests without mocking', () => {
         })
         expect(requestUri).toEqual('https://api.todoist.com/rest/v2/tasks?ids=12345%2C56789')
     })
+
+    test('GET calls do not serialise null values', () => {
+        const requestUri = axios.create().getUri({
+            method: 'GET',
+            baseURL: DEFAULT_BASE_URI,
+            params: {
+                ids: null,
+            },
+            paramsSerializer: {
+                serialize: paramsSerializer,
+            },
+        })
+        expect(requestUri).toEqual('https://api.todoist.com/rest/v2/tasks')
+    })
+
+    test('GET calls do not serialise undefined values', () => {
+        const requestUri = axios.create().getUri({
+            method: 'GET',
+            baseURL: DEFAULT_BASE_URI,
+            params: {
+                ids: undefined,
+            },
+            paramsSerializer: {
+                serialize: paramsSerializer,
+            },
+        })
+        expect(requestUri).toEqual('https://api.todoist.com/rest/v2/tasks')
+    })
 })

--- a/src/restClient.ts
+++ b/src/restClient.ts
@@ -12,10 +12,12 @@ export function paramsSerializer(params: Record<string, unknown>) {
 
     Object.keys(params).forEach((key) => {
         const value = params[key]
-        if (Array.isArray(value)) {
-            qs.append(key, value.join(','))
-        } else {
-            qs.append(key, String(value))
+        if (value != null) {
+            if (Array.isArray(value)) {
+                qs.append(key, value.join(','))
+            } else {
+                qs.append(key, String(value))
+            }
         }
     })
 


### PR DESCRIPTION
When making a GET request, any values that come through as `null` should not be serialised as they will essentially become strings of `'null'` when going to the backend. 

Fixes https://github.com/Doist/todoist-api-typescript/issues/292