### PR TITLE
docs: change API methods  description

### DIFF
--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -186,7 +186,7 @@ export class TodoistApi {
      * Creates a new task with the provided parameters.
      *
      * @param args - Task creation parameters such as content, due date, or priority.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the created task.
      */
     async addTask(args: AddTaskArgs, requestId?: string): Promise<Task> {
@@ -225,7 +225,7 @@ export class TodoistApi {
      *
      * @param id - The unique identifier of the task to update.
      * @param args - Update parameters such as content, priority, or due date.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the updated task.
      */
     async updateTask(id: string, args: UpdateTaskArgs, requestId?: string): Promise<Task> {
@@ -247,7 +247,7 @@ export class TodoistApi {
      *
      * @param ids - The unique identifier of the tasks to be moved.
      * @param args - The paramets that should contain only one of projectId, sectionId, or parentId
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns - A promise that resolves to an array of the updated tasks.
      */
     async moveTasks(ids: string[], args: MoveTaskArgs, requestId?: string): Promise<Task[]> {
@@ -305,7 +305,7 @@ export class TodoistApi {
      * Closes (completes) a task by its ID.
      *
      * @param id - The unique identifier of the task to close.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async closeTask(id: string, requestId?: string): Promise<boolean> {
@@ -325,7 +325,7 @@ export class TodoistApi {
      * Reopens a previously closed (completed) task by its ID.
      *
      * @param id - The unique identifier of the task to reopen.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async reopenTask(id: string, requestId?: string): Promise<boolean> {
@@ -345,7 +345,7 @@ export class TodoistApi {
      * Deletes a task by its ID.
      *
      * @param id - The unique identifier of the task to delete.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteTask(id: string, requestId?: string): Promise<boolean> {
@@ -406,7 +406,7 @@ export class TodoistApi {
      * Creates a new project with the provided parameters.
      *
      * @param args - Project creation parameters such as name or color.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the created project.
      */
     async addProject(
@@ -430,7 +430,7 @@ export class TodoistApi {
      *
      * @param id - The unique identifier of the project to update.
      * @param args - Update parameters such as name or color.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the updated project.
      */
     async updateProject(
@@ -455,7 +455,7 @@ export class TodoistApi {
      * Deletes a project by its ID.
      *
      * @param id - The unique identifier of the project to delete.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteProject(id: string, requestId?: string): Promise<boolean> {
@@ -544,7 +544,7 @@ export class TodoistApi {
      * Creates a new section within a project.
      *
      * @param args - Section creation parameters such as name or project ID.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the created section.
      */
     async addSection(args: AddSectionArgs, requestId?: string): Promise<Section> {
@@ -565,7 +565,7 @@ export class TodoistApi {
      *
      * @param id - The unique identifier of the section to update.
      * @param args - Update parameters such as name or project ID.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the updated section.
      */
     async updateSection(id: string, args: UpdateSectionArgs, requestId?: string): Promise<Section> {
@@ -585,7 +585,7 @@ export class TodoistApi {
      * Deletes a section by its ID.
      *
      * @param id - The unique identifier of the section to delete.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteSection(id: string, requestId?: string): Promise<boolean> {
@@ -646,7 +646,7 @@ export class TodoistApi {
      * Adds a new label.
      *
      * @param args - Label creation parameters such as name.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the created label.
      */
     async addLabel(args: AddLabelArgs, requestId?: string): Promise<Label> {
@@ -667,7 +667,7 @@ export class TodoistApi {
      *
      * @param id - The unique identifier of the label to update.
      * @param args - Update parameters such as name or color.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the updated label.
      */
     async updateLabel(id: string, args: UpdateLabelArgs, requestId?: string): Promise<Label> {
@@ -687,7 +687,7 @@ export class TodoistApi {
      * Deletes a label by its ID.
      *
      * @param id - The unique identifier of the label to delete.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteLabel(id: string, requestId?: string): Promise<boolean> {
@@ -806,7 +806,7 @@ export class TodoistApi {
      * Adds a comment to a task or project.
      *
      * @param args - Parameters for creating the comment, such as content and the target task or project ID.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the created comment.
      */
     async addComment(args: AddCommentArgs, requestId?: string): Promise<Comment> {
@@ -827,7 +827,7 @@ export class TodoistApi {
      *
      * @param id - The unique identifier of the comment to update.
      * @param args - Update parameters such as new content.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to the updated comment.
      */
     async updateComment(id: string, args: UpdateCommentArgs, requestId?: string): Promise<Comment> {
@@ -847,7 +847,7 @@ export class TodoistApi {
      * Deletes a comment by its ID.
      *
      * @param id - The unique identifier of the comment to delete.
-     * @param requestId - Optional unique identifier for idempotency.
+     * @param requestId - Optional custom identifier for the request.
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteComment(id: string, requestId?: string): Promise<boolean> {

--- a/website/docs/api/classes/TodoistApi.md
+++ b/website/docs/api/classes/TodoistApi.md
@@ -55,7 +55,7 @@ Adds a comment to a task or project.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `args` | [`AddCommentArgs`](../type-aliases/AddCommentArgs.md) | Parameters for creating the comment, such as content and the target task or project ID. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -78,7 +78,7 @@ Adds a new label.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `args` | [`AddLabelArgs`](../type-aliases/AddLabelArgs.md) | Label creation parameters such as name. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -103,7 +103,7 @@ Creates a new project with the provided parameters.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `args` | [`AddProjectArgs`](../type-aliases/AddProjectArgs.md) | Project creation parameters such as name or color. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -128,7 +128,7 @@ Creates a new section within a project.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `args` | [`AddSectionArgs`](../type-aliases/AddSectionArgs.md) | Section creation parameters such as name or project ID. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -151,7 +151,7 @@ Creates a new task with the provided parameters.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `args` | [`AddTaskArgs`](../type-aliases/AddTaskArgs.md) | Task creation parameters such as content, due date, or priority. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -174,7 +174,7 @@ Closes (completes) a task by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the task to close. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -197,7 +197,7 @@ Deletes a comment by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the comment to delete. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -220,7 +220,7 @@ Deletes a label by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the label to delete. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -243,7 +243,7 @@ Deletes a project by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the project to delete. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -266,7 +266,7 @@ Deletes a section by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the section to delete. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -289,7 +289,7 @@ Deletes a task by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the task to delete. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -609,7 +609,7 @@ Moves existing tasks by their ID to either a different parent/section/project.
 | ------ | ------ | ------ |
 | `ids` | `string`[] | The unique identifier of the tasks to be moved. |
 | `args` | [`MoveTaskArgs`](../type-aliases/MoveTaskArgs.md) | The paramets that should contain only one of projectId, sectionId, or parentId |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -698,7 +698,7 @@ Reopens a previously closed (completed) task by its ID.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the task to reopen. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -725,7 +725,7 @@ Updates an existing comment by its ID.
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the comment to update. |
 | `args` | [`UpdateCommentArgs`](../type-aliases/UpdateCommentArgs.md) | Update parameters such as new content. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -752,7 +752,7 @@ Updates an existing label by its ID.
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the label to update. |
 | `args` | [`UpdateLabelArgs`](../type-aliases/UpdateLabelArgs.md) | Update parameters such as name or color. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -781,7 +781,7 @@ Updates an existing project by its ID with the provided parameters.
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the project to update. |
 | `args` | [`UpdateProjectArgs`](../type-aliases/UpdateProjectArgs.md) | Update parameters such as name or color. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -810,7 +810,7 @@ Updates a section by its ID with the provided parameters.
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the section to update. |
 | `args` | [`UpdateSectionArgs`](../type-aliases/UpdateSectionArgs.md) | Update parameters such as name or project ID. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 
@@ -837,7 +837,7 @@ Updates an existing task by its ID with the provided parameters.
 | ------ | ------ | ------ |
 | `id` | `string` | The unique identifier of the task to update. |
 | `args` | [`UpdateTaskArgs`](../type-aliases/UpdateTaskArgs.md) | Update parameters such as content, priority, or due date. |
-| `requestId`? | `string` | Optional unique identifier for idempotency. |
+| `requestId`? | `string` | Optional custom identifier for the request. |
 
 #### Returns
 

--- a/website/docs/api/type-aliases/Permission.md
+++ b/website/docs/api/type-aliases/Permission.md
@@ -6,7 +6,8 @@ type Permission =
   | "data:read"
   | "data:read_write"
   | "data:delete"
-  | "project:delete";
+  | "project:delete"
+  | "backups:read";
 ```
 
 Permission scopes that can be requested during OAuth2 authorization.


### PR DESCRIPTION
`requestId` does not guarantee idempotency. Setting this field just customizes the `X-Request-ID` HTTP header, which can be useful for things like logging.