### PR TITLE
Move-tasks discards additional tasks because of a duplicate uuid

### DIFF
--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -254,10 +254,9 @@ export class TodoistApi {
         if (ids.length > MAX_COMMAND_COUNT) {
             throw new TodoistRequestError(`Maximum number of items is ${MAX_COMMAND_COUNT}`, 400)
         }
-        const uuid = uuidv4()
         const commands: Command[] = ids.map((id) => ({
             type: 'item_move',
-            uuid,
+            uuid: uuidv4(),
             args: {
                 id,
                 ...(args.projectId && { project_id: args.projectId }),


### PR DESCRIPTION
All tasks in the moveTasks method shared a UUID4, which caused the server to ignore all tasks but the first. Use a new UUID4 for each task. Tested with todoist-mcp.