### PR TITLE
Add archive/unarchive project endpoint and tests

### DIFF
--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -213,4 +213,60 @@ describe('TodoistApi project endpoints', () => {
             expect(nextCursor).toBe('123')
         })
     })
+
+    describe('archiveProject', () => {
+        test('calls POST on archive endpoint with expected parameters', async () => {
+            const projectId = '123'
+            const requestMock = setupRestClientMock(DEFAULT_PROJECT)
+            const api = getTarget()
+
+            await api.archiveProject(projectId, DEFAULT_REQUEST_ID)
+
+            expect(requestMock).toBeCalledTimes(1)
+            expect(requestMock).toBeCalledWith(
+                'POST',
+                getSyncBaseUri(),
+                `${ENDPOINT_REST_PROJECTS}/${projectId}/archive`,
+                DEFAULT_AUTH_TOKEN,
+                undefined,
+                DEFAULT_REQUEST_ID,
+            )
+        })
+
+        test('returns result from rest client', async () => {
+            setupRestClientMock(DEFAULT_PROJECT)
+            const api = getTarget()
+
+            const project = await api.archiveProject('123')
+            expect(project).toEqual(DEFAULT_PROJECT)
+        })
+    })
+
+    describe('unarchiveProject', () => {
+        test('calls POST on unarchive endpoint with expected parameters', async () => {
+            const projectId = '123'
+            const requestMock = setupRestClientMock(DEFAULT_PROJECT)
+            const api = getTarget()
+
+            await api.unarchiveProject(projectId, DEFAULT_REQUEST_ID)
+
+            expect(requestMock).toBeCalledTimes(1)
+            expect(requestMock).toBeCalledWith(
+                'POST',
+                getSyncBaseUri(),
+                `${ENDPOINT_REST_PROJECTS}/${projectId}/unarchive`,
+                DEFAULT_AUTH_TOKEN,
+                undefined,
+                DEFAULT_REQUEST_ID,
+            )
+        })
+
+        test('returns result from rest client', async () => {
+            setupRestClientMock(DEFAULT_PROJECT)
+            const api = getTarget()
+
+            const project = await api.unarchiveProject('123')
+            expect(project).toEqual(DEFAULT_PROJECT)
+        })
+    })
 })

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -526,6 +526,52 @@ export class TodoistApi {
     }
 
     /**
+     * Archives a project by its ID.
+     *
+     * @param id - The unique identifier of the project to archive.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns A promise that resolves to the updated project.
+     */
+    async archiveProject(
+        id: string,
+        requestId?: string,
+    ): Promise<PersonalProject | WorkspaceProject> {
+        z.string().parse(id)
+        const response = await request<PersonalProject | WorkspaceProject>(
+            'POST',
+            this.syncApiBase,
+            generatePath(ENDPOINT_REST_PROJECTS, id, 'archive'),
+            this.authToken,
+            undefined,
+            requestId,
+        )
+        return validateProject(response.data)
+    }
+
+    /**
+     * Unarchives a project by its ID.
+     *
+     * @param id - The unique identifier of the project to unarchive.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns A promise that resolves to the updated project.
+     */
+    async unarchiveProject(
+        id: string,
+        requestId?: string,
+    ): Promise<PersonalProject | WorkspaceProject> {
+        z.string().parse(id)
+        const response = await request<PersonalProject | WorkspaceProject>(
+            'POST',
+            this.syncApiBase,
+            generatePath(ENDPOINT_REST_PROJECTS, id, 'unarchive'),
+            this.authToken,
+            undefined,
+            requestId,
+        )
+        return validateProject(response.data)
+    }
+
+    /**
      * Retrieves a list of collaborators for a specific project.
      *
      * @param projectId - The unique identifier of the project.


### PR DESCRIPTION
Added support for archiving and unarchiving projects through new API endpoints. Also included tests to make sure these features work as expected.
  
  Docs used for reference
- [Archive](https://developer.todoist.com/api/v1/#tag/Projects/operation/archive_project_api_v1_projects__project_id__archive_post)  
- [Unarchive](https://developer.todoist.com/api/v1/#tag/Projects/operation/unarchive_project_api_v1_projects__project_id__unarchive_post)  
