### PR TITLE
feat: Added GetArchivedProjects API Endpoint

### DIFF
--- a/src/TodoistApi.projects.test.ts
+++ b/src/TodoistApi.projects.test.ts
@@ -270,5 +270,37 @@ describe('TodoistApi project endpoints', () => {
             const project = await api.unarchiveProject('123')
             expect(project).toEqual(DEFAULT_PROJECT)
         })
+
+        describe('getArchivedProjects', () => {
+            test('calls get on archived projects endpoint', async () => {
+                const requestMock = setupRestClientMock({
+                    results: [DEFAULT_PROJECT],
+                    nextCursor: 'abc',
+                })
+                const api = getTarget()
+
+                const args = { limit: 10, cursor: '0' }
+                await api.getArchivedProjects(args)
+
+                expect(requestMock).toHaveBeenCalledTimes(1)
+                expect(requestMock).toHaveBeenCalledWith(
+                    'GET',
+                    getSyncBaseUri(),
+                    'projects/archived',
+                    DEFAULT_AUTH_TOKEN,
+                    args,
+                )
+            })
+
+            test('returns result from rest client', async () => {
+                const projects = [DEFAULT_PROJECT, PROJECT_WITH_OPTIONALS_AS_NULL]
+                setupRestClientMock({ results: projects, nextCursor: 'abc' })
+                const api = getTarget()
+
+                const { results, nextCursor } = await api.getArchivedProjects()
+                expect(results).toEqual(projects)
+                expect(nextCursor).toBe('abc')
+            })
+        })
     })
 })

--- a/src/TodoistApi.ts
+++ b/src/TodoistApi.ts
@@ -33,6 +33,8 @@ import {
     GetCompletedTasksByCompletionDateArgs,
     GetCompletedTasksByDueDateArgs,
     GetCompletedTasksResponse,
+    GetArchivedProjectsArgs,
+    GetArchivedProjectsResponse,
 } from './types/requests'
 import { request, isSuccess } from './restClient'
 import {
@@ -55,6 +57,7 @@ import {
     ENDPOINT_SYNC,
     PROJECT_ARCHIVE,
     PROJECT_UNARCHIVE,
+    ENDPOINT_REST_PROJECTS_ARCHIVED,
 } from './consts/endpoints'
 import {
     validateComment,
@@ -448,6 +451,31 @@ export class TodoistApi {
             'GET',
             this.syncApiBase,
             ENDPOINT_REST_PROJECTS,
+            this.authToken,
+            args,
+        )
+
+        return {
+            results: validateProjectArray(results),
+            nextCursor,
+        }
+    }
+
+    /**
+     * Retrieves all archived projects with optional filters.
+     *
+     * @param args - Optional filters for retrieving archived projects.
+     * @returns A promise that resolves to an array of archived projects.
+     */
+    async getArchivedProjects(
+        args: GetArchivedProjectsArgs = {},
+    ): Promise<GetArchivedProjectsResponse> {
+        const {
+            data: { results, nextCursor },
+        } = await request<GetArchivedProjectsResponse>(
+            'GET',
+            this.syncApiBase,
+            ENDPOINT_REST_PROJECTS_ARCHIVED,
             this.authToken,
             args,
         )

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -23,7 +23,6 @@ export const ENDPOINT_REST_TASKS_COMPLETED_BY_COMPLETION_DATE =
     ENDPOINT_REST_TASKS + '/completed/by_completion_date'
 export const ENDPOINT_REST_TASKS_COMPLETED_BY_DUE_DATE =
     ENDPOINT_REST_TASKS + '/completed/by_due_date'
-export const ENDPOINT_REST_PROJECTS = 'projects'
 export const ENDPOINT_REST_SECTIONS = 'sections'
 export const ENDPOINT_REST_LABELS = 'labels'
 export const ENDPOINT_REST_LABELS_SHARED = ENDPOINT_REST_LABELS + '/shared'
@@ -32,6 +31,8 @@ export const ENDPOINT_REST_LABELS_SHARED_REMOVE = ENDPOINT_REST_LABELS_SHARED + 
 export const ENDPOINT_REST_COMMENTS = 'comments'
 export const ENDPOINT_REST_TASK_CLOSE = 'close'
 export const ENDPOINT_REST_TASK_REOPEN = 'reopen'
+export const ENDPOINT_REST_PROJECTS = 'projects'
+export const ENDPOINT_REST_PROJECTS_ARCHIVED = ENDPOINT_REST_PROJECTS + '/archived'
 export const ENDPOINT_REST_PROJECT_COLLABORATORS = 'collaborators'
 export const PROJECT_ARCHIVE = 'archive'
 export const PROJECT_UNARCHIVE = 'unarchive'

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -104,7 +104,7 @@ export const BaseProjectSchema = z.object({
  */
 export const PersonalProjectSchema = BaseProjectSchema.extend({
     parentId: z.string().nullable(),
-    inboxProject: z.boolean(),
+    inboxProject: z.boolean().optional().default(false),
 }).transform((data) => {
     return {
         ...data,

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -184,6 +184,24 @@ export type GetProjectsResponse = {
 }
 
 /**
+ * Arguments for retrieving archived projects.
+ * @see https://todoist.com/api/v1/docs#tag/Projects/operation/get_archived_projects_api_v1_projects_archived_get
+ */
+export type GetArchivedProjectsArgs = {
+    cursor?: string | null
+    limit?: number
+}
+
+/**
+ * Response from retrieving archived projects.
+ * @see https://todoist.com/api/v1/docs#tag/Projects/operation/get_archived_projects_api_v1_projects_archived_get
+ */
+export type GetArchivedProjectsResponse = {
+    results: (PersonalProject | WorkspaceProject)[]
+    nextCursor: string | null
+}
+
+/**
  * Arguments for creating a new project.
  * @see https://todoist.com/api/v1/docs#tag/Projects/operation/create_project_api_v1_projects_post
  */


### PR DESCRIPTION
**Added support for retrieving archived projects via a new getArchivedProjects method in the API client.**

- Adds endpoint constant and request/response types
- Implements the method in TodoistApi
- Includes tests for the new endpoint
- Updates validation to handle missing inboxProject field in archived projects

[Docs](https://developer.todoist.com/api/v1/#tag/Projects/operation/get_archived_api_v1_projects_archived_get)