### PR TITLE
fix: Remove dual publishing to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,3 @@ jobs:
               run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
-            # Publish to GitHub package registry
-            - uses: actions/setup-node@v4
-              with:
-                  node-version-file: .nvmrc
-                  scope: '@doist'
-                  registry-url: 'https://npm.pkg.github.com/'
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@doist:registry=https://npm.pkg.github.com/


### PR DESCRIPTION
## Summary
- Removes dual publishing to GitHub Packages from the publish workflow
- Removes `.npmrc` file since it's no longer needed

## Problem
The v5.6.0 release failed because the workflow attempts to publish to both npmjs.org and GitHub Packages. The GitHub Packages publish step failed with an authentication error, preventing the release from completing.

Looking at the logs, the package was never actually published to npm - the failure happened before npm publish completed.

## Background
Dual publishing was added in #158 (Oct 2022, 2.5 years ago) to support internal projects that pulled `@doist` packages from GitHub Packages. Since this is a public package, there's no reason internal projects can't simply pull it from npmjs.org like everyone else.

## Changes
- Remove GitHub Packages publishing step from workflow
- Remove `.npmrc` file (was only needed for GitHub Packages registry config)

## Next Steps
After merging, we'll need to delete and recreate the v5.6.0 release to re-trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)