### PR TITLE
chore: Exports the url helpers from root export

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './colors'
 export * from './sanitization'
+export * from './urlHelpers'


### PR DESCRIPTION
The Url helper functions were not being exported at the root level which meant having to import from `@doist/todoist-api-typescript/dist/utils/urlHelpers`. No thank you. 

This PR addresses that. 