### PR TITLE
feat: Add moveTask method for single task moves

### DIFF
--- a/src/TodoistApi.moveTask.test.ts
+++ b/src/TodoistApi.moveTask.test.ts
@@ -1,0 +1,121 @@
+import { TodoistApi } from '.'
+import { DEFAULT_AUTH_TOKEN, DEFAULT_REQUEST_ID, DEFAULT_TASK } from './testUtils/testDefaults'
+import { getSyncBaseUri, ENDPOINT_REST_TASKS, ENDPOINT_REST_TASK_MOVE } from './consts/endpoints'
+import { setupRestClientMock } from './testUtils/mocks'
+import { getTaskUrl } from './utils/urlHelpers'
+
+function getTarget(baseUrl = 'https://api.todoist.com') {
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+}
+
+describe('TodoistApi moveTask', () => {
+    const TASK_ID = '123'
+    const PROJECT_ID = '999'
+    const SECTION_ID = '888'
+    const PARENT_ID = '777'
+
+    describe.each([
+        {
+            description: 'project',
+            args: { projectId: PROJECT_ID },
+            expectedApiArgs: { project_id: PROJECT_ID },
+            expectedTaskProps: { projectId: PROJECT_ID },
+        },
+        {
+            description: 'section',
+            args: { sectionId: SECTION_ID },
+            expectedApiArgs: { section_id: SECTION_ID },
+            expectedTaskProps: { sectionId: SECTION_ID },
+        },
+        {
+            description: 'parent',
+            args: { parentId: PARENT_ID },
+            expectedApiArgs: { parent_id: PARENT_ID },
+            expectedTaskProps: { parentId: PARENT_ID },
+        },
+    ])('moving task to $description', ({ args, expectedApiArgs, expectedTaskProps }) => {
+        test('calls post on restClient with expected parameters', async () => {
+            const movedTask = {
+                ...DEFAULT_TASK,
+                id: TASK_ID,
+                ...expectedTaskProps,
+                url: getTaskUrl(TASK_ID, DEFAULT_TASK.content),
+            }
+            const requestMock = setupRestClientMock(movedTask)
+            const api = getTarget()
+
+            await api.moveTask(TASK_ID, args, DEFAULT_REQUEST_ID)
+
+            expect(requestMock).toHaveBeenCalledTimes(1)
+            expect(requestMock).toHaveBeenCalledWith(
+                'POST',
+                getSyncBaseUri(),
+                `${ENDPOINT_REST_TASKS}/${TASK_ID}/${ENDPOINT_REST_TASK_MOVE}`,
+                DEFAULT_AUTH_TOKEN,
+                expectedApiArgs,
+                DEFAULT_REQUEST_ID,
+            )
+        })
+
+        test('returns moved task', async () => {
+            const movedTask = {
+                ...DEFAULT_TASK,
+                id: TASK_ID,
+                ...expectedTaskProps,
+                url: getTaskUrl(TASK_ID, DEFAULT_TASK.content),
+            }
+            setupRestClientMock(movedTask)
+            const api = getTarget()
+
+            const result = await api.moveTask(TASK_ID, args)
+
+            expect(result).toEqual(movedTask)
+        })
+    })
+
+    test('calls post on restClient with expected parameters against staging', async () => {
+        const movedTask = {
+            ...DEFAULT_TASK,
+            id: TASK_ID,
+            projectId: PROJECT_ID,
+            url: getTaskUrl(TASK_ID, DEFAULT_TASK.content),
+        }
+        const requestMock = setupRestClientMock(movedTask)
+        const api = getTarget('https://staging.todoist.com')
+
+        await api.moveTask(TASK_ID, { projectId: PROJECT_ID }, DEFAULT_REQUEST_ID)
+
+        expect(requestMock).toHaveBeenCalledTimes(1)
+        expect(requestMock).toHaveBeenCalledWith(
+            'POST',
+            getSyncBaseUri('https://staging.todoist.com'),
+            `${ENDPOINT_REST_TASKS}/${TASK_ID}/${ENDPOINT_REST_TASK_MOVE}`,
+            DEFAULT_AUTH_TOKEN,
+            { project_id: PROJECT_ID },
+            DEFAULT_REQUEST_ID,
+        )
+    })
+
+    test('works without requestId', async () => {
+        const movedTask = {
+            ...DEFAULT_TASK,
+            id: TASK_ID,
+            projectId: PROJECT_ID,
+            url: getTaskUrl(TASK_ID, DEFAULT_TASK.content),
+        }
+        const requestMock = setupRestClientMock(movedTask)
+        const api = getTarget()
+
+        await api.moveTask(TASK_ID, { projectId: PROJECT_ID })
+
+        expect(requestMock).toHaveBeenCalledTimes(1)
+        expect(requestMock).toHaveBeenCalledWith(
+            'POST',
+            getSyncBaseUri(),
+            `${ENDPOINT_REST_TASKS}/${TASK_ID}/${ENDPOINT_REST_TASK_MOVE}`,
+            DEFAULT_AUTH_TOKEN,
+            { project_id: PROJECT_ID },
+            undefined,
+        )
+    })
+})

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -32,6 +32,7 @@ export const ENDPOINT_REST_LABELS_SHARED_REMOVE = ENDPOINT_REST_LABELS_SHARED + 
 export const ENDPOINT_REST_COMMENTS = 'comments'
 export const ENDPOINT_REST_TASK_CLOSE = 'close'
 export const ENDPOINT_REST_TASK_REOPEN = 'reopen'
+export const ENDPOINT_REST_TASK_MOVE = 'move'
 export const ENDPOINT_REST_PROJECTS = 'projects'
 export const ENDPOINT_REST_PROJECTS_ARCHIVED = ENDPOINT_REST_PROJECTS + '/archived'
 export const ENDPOINT_REST_PROJECT_COLLABORATORS = 'collaborators'


### PR DESCRIPTION
## Summary

- Adds a new `moveTask` method that uses the REST API v1 `/tasks/{id}/move` endpoint for moving individual tasks
- Marks the existing `moveTasks` method as deprecated (it uses the older Sync API for batch operations)
- Provides a more efficient way to move single tasks to different projects, sections, or parents

## Changes

- **New method**: `moveTask(id: string, args: MoveTaskArgs, requestId?: string): Promise<Task>`
- **Deprecation**: `moveTasks` is now marked as deprecated with migration guidance
- **Tests**: Comprehensive parameterized tests covering all move scenarios (8 tests total)

## Test plan

- [x] All new tests passing (8/8)
- [x] All existing tests still passing (233/233)
- [x] Linting successful
- [x] TypeScript compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)