### PR TITLE
chore: Updates `uuid` package and removes types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,13 @@
                 "camelcase": "6.3.0",
                 "emoji-regex": "10.5.0",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^11.0.0",
+                "uuid": "11.1.0",
                 "zod": "4.1.5"
             },
             "devDependencies": {
                 "@doist/eslint-config": "11.1.0",
                 "@doist/prettier-config": "4.0.0",
                 "@types/jest": "30.0.0",
-                "@types/uuid": "10.0.0",
                 "@typescript-eslint/eslint-plugin": "6.21.0",
                 "@typescript-eslint/parser": "6.21.0",
                 "eslint": "8.35.0",
@@ -1767,12 +1766,6 @@
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
@@ -8724,6 +8717,7 @@
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }
@@ -10405,12 +10399,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "dev": true
-        },
-        "@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
             "dev": true
         },
         "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
         "camelcase": "6.3.0",
         "emoji-regex": "10.5.0",
         "ts-custom-error": "^3.2.0",
-        "uuid": "^11.0.0",
+        "uuid": "11.1.0",
         "zod": "4.1.5"
     },
     "devDependencies": {
         "@doist/eslint-config": "11.1.0",
         "@doist/prettier-config": "4.0.0",
         "@types/jest": "30.0.0",
-        "@types/uuid": "10.0.0",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "eslint": "8.35.0",


### PR DESCRIPTION
This updates to v11 of uuid and removes the types package as it's deprecated now. 