### PR TITLE
feat: [BREAKING] Set minimum Node.js to 20+ 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "types": "dist/index.d.ts",
     "sideEffects": false,
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "clean": "rimraf dist",


### PR DESCRIPTION
## Summary
- Updates minimum Node.js version from 8.0.0 to 20.0.0
- Prepares for migration from axios to native fetch API
- Node.js 20+ provides stable fetch support and is current LTS

## Test plan
- [x] Verify package.json engines field updated
- [x] Confirm existing tests still pass with Node 20+
- [ ] CI/CD pipeline validation with new Node requirement


🤖 Generated with [Claude Code](https://claude.com/claude-code)