### PR TITLE
fix: Correct the deprecations

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -155,8 +155,9 @@ export function getAuthorizationUrl({
  */
 export async function getAuthToken(
     args: AuthTokenRequestArgs,
-    baseUrl?: string,
+    baseUrl: string,
 ): Promise<AuthTokenResponse>
+export async function getAuthToken(args: AuthTokenRequestArgs): Promise<AuthTokenResponse>
 export async function getAuthToken(
     args: AuthTokenRequestArgs,
     options?: AuthOptions,
@@ -230,8 +231,9 @@ export async function getAuthToken(
  */
 export async function revokeAuthToken(
     args: RevokeAuthTokenRequestArgs,
-    baseUrl?: string,
+    baseUrl: string,
 ): Promise<boolean>
+export async function revokeAuthToken(args: RevokeAuthTokenRequestArgs): Promise<boolean>
 export async function revokeAuthToken(
     args: RevokeAuthTokenRequestArgs,
     options?: AuthOptions,
@@ -287,7 +289,8 @@ export async function revokeAuthToken(
 /**
  * @deprecated Use options object instead: revokeToken(args, { baseUrl, customFetch })
  */
-export async function revokeToken(args: RevokeTokenRequestArgs, baseUrl?: string): Promise<boolean>
+export async function revokeToken(args: RevokeTokenRequestArgs, baseUrl: string): Promise<boolean>
+export async function revokeToken(args: RevokeTokenRequestArgs): Promise<boolean>
 export async function revokeToken(
     args: RevokeTokenRequestArgs,
     options?: AuthOptions,

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -195,7 +195,8 @@ export class TodoistApi {
     /**
      * @deprecated Use options object instead: new TodoistApi(token, { baseUrl, customFetch })
      */
-    constructor(authToken: string, baseUrl?: string)
+    constructor(authToken: string, baseUrl: string)
+    constructor(authToken: string)
     constructor(authToken: string, options?: TodoistApiOptions)
     constructor(
         /**


### PR DESCRIPTION
Doing something like `const api = new TodoistApi(token)` was giving a deprecated message because the overload was incorrect on the deprecation message. Have corrected this on the TodoistApi and the authentication functions.