### PR TITLE
fix: Remove dependency on `projectId` for GetSectionsArgs

### DIFF
--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -259,7 +259,7 @@ export type GetProjectCollaboratorsResponse = {
  * @see https://todoist.com/api/v1/docs#tag/Sections/operation/get_sections_api_v1_sections_get
  */
 export type GetSectionsArgs = {
-    projectId: string | null
+    projectId?: string | null
     cursor?: string | null
     limit?: number
 }


### PR DESCRIPTION
Follow on from #395. Whilst the previous PR made it so you didn't have to provide the args, that doesn't work if you don't want to provide a project ID, but you _do_ want to provide limits/cursor for pagination.