### PR TITLE
chore: Update tests to not use deprecator ctor

### DIFF
--- a/src/todoist-api.activities.test.ts
+++ b/src/todoist-api.activities.test.ts
@@ -4,7 +4,7 @@ import { getSyncBaseUri, ENDPOINT_REST_ACTIVITIES } from './consts/endpoints'
 import { server, http, HttpResponse } from './test-utils/msw-setup'
 
 function getTarget(baseUrl = 'https://api.todoist.com') {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, { baseUrl })
 }
 
 const DEFAULT_ACTIVITY_RESPONSE: ActivityEvent[] = [

--- a/src/todoist-api.move-task.test.ts
+++ b/src/todoist-api.move-task.test.ts
@@ -5,7 +5,7 @@ import { server, http, HttpResponse } from './test-utils/msw-setup'
 import { getTaskUrl } from './utils/url-helpers'
 
 function getTarget(baseUrl = 'https://api.todoist.com') {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, { baseUrl })
 }
 
 describe('TodoistApi moveTask', () => {

--- a/src/todoist-api.move-tasks.test.ts
+++ b/src/todoist-api.move-tasks.test.ts
@@ -21,7 +21,7 @@ type SyncPayload = {
 }
 
 function getTarget(baseUrl = 'https://api.todoist.com') {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, { baseUrl })
 }
 
 describe('TodoistApi moveTasks', () => {

--- a/src/todoist-api.tasks.test.ts
+++ b/src/todoist-api.tasks.test.ts
@@ -20,7 +20,7 @@ import { server, http, HttpResponse } from './test-utils/msw-setup'
 import { getTaskUrl } from './utils/url-helpers'
 
 function getTarget(baseUrl = 'https://api.todoist.com') {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, { baseUrl })
 }
 
 describe('TodoistApi task endpoints', () => {

--- a/src/todoist-api.user.test.ts
+++ b/src/todoist-api.user.test.ts
@@ -4,7 +4,7 @@ import { getSyncBaseUri, ENDPOINT_REST_USER, ENDPOINT_REST_PRODUCTIVITY } from '
 import { server, http, HttpResponse } from './test-utils/msw-setup'
 
 function getTarget(baseUrl = 'https://api.todoist.com') {
-    return new TodoistApi(DEFAULT_AUTH_TOKEN, baseUrl)
+    return new TodoistApi(DEFAULT_AUTH_TOKEN, { baseUrl })
 }
 
 const DEFAULT_CURRENT_USER_RESPONSE: CurrentUser = {


### PR DESCRIPTION
In CI runs we were seeing a lot of warnings about deprecated usages of TodoistApi's contructor with a baseurl. This PR brings those usgages inline with the new way of constructing it.