### PR TITLE
fix: Fix script hanging for 30 seconds

### DIFF
--- a/src/utils/fetch-with-retry.ts
+++ b/src/utils/fetch-with-retry.ts
@@ -53,7 +53,9 @@ function createTimeoutSignal(
         controller.abort(new Error(`Request timeout after ${timeoutMs}ms`))
     }, timeoutMs)
 
-    const clear = () => clearTimeout(timeoutId)
+    function clear() {
+        clearTimeout(timeoutId)
+    }
 
     // If there's an existing signal, forward its abort
     if (existingSignal) {


### PR DESCRIPTION
Here are some changes made, using GPT-5, which fixed the issue in #406 for me. 

Specifically, it appears to be [this line](https://github.com/garyking/todoist-api-typescript/blob/1301400fdde7eb89370537af3531122c2e146fc9/src/utils/fetch-with-retry.ts#L196) that fixes the issue for me.