### PR TITLE
fix: Exclude website folder from triggering releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,6 +4,7 @@
         ".": {
             "release-type": "node",
             "package-name": "@doist/todoist-api-typescript",
+            "exclude-paths": ["website"],
             "changelog-sections": [
                 { "type": "feat", "section": "Features" },
                 { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Add `exclude-paths: ["website"]` to release-please configuration
- Prevents website dependency updates from triggering unnecessary releases

## Problem
Website folder changes (like Dependabot dependency updates) were triggering unwanted releases for the main `@doist/todoist-api-typescript` package. Recent examples include `node-forge` bumps in the website folder that resulted in main package releases.

## Solution  
Configure release-please to exclude the `website` directory from release triggers by adding `exclude-paths` to the configuration.

## Test Plan
- [x] Verify configuration syntax is valid JSON
- [ ] Monitor next website dependency update to confirm no release is triggered
- [ ] Verify main package changes still trigger releases properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)