### PR TITLE
feat: Add getWorkspaces() method and refactor Sync API request handling

### DIFF
--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -584,3 +584,56 @@ export const JoinWorkspaceResultSchema = z.object({
  * Result returned when successfully joining a workspace.
  */
 export type JoinWorkspaceResult = z.infer<typeof JoinWorkspaceResultSchema>
+
+/**
+ * Available workspace plans.
+ */
+export const WORKSPACE_PLANS = ['STARTER', 'BUSINESS'] as const
+
+/**
+ * Workspace plan type.
+ */
+export type WorkspacePlan = (typeof WORKSPACE_PLANS)[number]
+
+export const WorkspacePlanSchema = z.enum(WORKSPACE_PLANS)
+
+/**
+ * Workspace resource limits.
+ */
+export const WorkspaceLimitsSchema = z
+    .object({
+        current: z.record(z.string(), z.any()).nullable(),
+        next: z.record(z.string(), z.any()).nullable(),
+    })
+    .catchall(z.any())
+
+export type WorkspaceLimits = z.infer<typeof WorkspaceLimitsSchema>
+
+/**
+ * Workspace properties (flexible object for unknown fields).
+ */
+export const WorkspacePropertiesSchema = z.record(z.string(), z.unknown())
+export type WorkspaceProperties = z.infer<typeof WorkspacePropertiesSchema>
+
+/**
+ * Represents a workspace in Todoist.
+ */
+export const WorkspaceSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    plan: WorkspacePlanSchema,
+    role: WorkspaceRoleSchema,
+    inviteCode: z.string(),
+    isLinkSharingEnabled: z.boolean(),
+    isGuestAllowed: z.boolean(),
+    limits: WorkspaceLimitsSchema,
+    logoBig: z.string().nullish(),
+    logoMedium: z.string().nullish(),
+    logoSmall: z.string().nullish(),
+    logoS640: z.string().nullish(),
+    createdAt: z.string(),
+    creatorId: z.string(),
+    properties: WorkspacePropertiesSchema,
+})
+
+export type Workspace = z.infer<typeof WorkspaceSchema>

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -14,12 +14,47 @@ export type SyncError = {
     httpCode: number
 }
 
+/**
+ * All available Sync API resource types.
+ */
+export const SYNC_RESOURCE_TYPES = [
+    'labels',
+    'projects',
+    'items',
+    'notes',
+    'sections',
+    'filters',
+    'reminders',
+    'reminders_location',
+    'locations',
+    'user',
+    'live_notifications',
+    'collaborators',
+    'user_settings',
+    'notification_settings',
+    'user_plan_limits',
+    'completed_info',
+    'stats',
+    'workspaces',
+    'workspace_users',
+    'workspace_filters',
+    'view_options',
+    'project_view_options_defaults',
+    'role_actions',
+] as const
+
+export type SyncResourceType = (typeof SYNC_RESOURCE_TYPES)[number]
+
 export type SyncRequest = {
-    commands: Command[]
-    resource_types?: string[]
+    commands?: Command[]
+    resource_types?: SyncResourceType[]
+    sync_token?: string
 }
 
 export type SyncResponse = {
     items?: Task[]
     syncStatus?: Record<string, 'ok' | SyncError>
+    syncToken?: string
+    fullSync?: boolean
+    workspaces?: Record<string, unknown>
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -29,6 +29,8 @@ import {
     type WorkspacePlanDetails,
     JoinWorkspaceResultSchema,
     type JoinWorkspaceResult,
+    WorkspaceSchema,
+    type Workspace,
 } from '../types/entities'
 
 export function validateTask(input: unknown): Task {
@@ -154,4 +156,12 @@ export function validateWorkspacePlanDetails(input: unknown): WorkspacePlanDetai
 
 export function validateJoinWorkspaceResult(input: unknown): JoinWorkspaceResult {
     return JoinWorkspaceResultSchema.parse(input)
+}
+
+export function validateWorkspace(input: unknown): Workspace {
+    return WorkspaceSchema.parse(input)
+}
+
+export function validateWorkspaceArray(input: unknown[]): Workspace[] {
+    return input.map(validateWorkspace)
 }


### PR DESCRIPTION
## Summary

Adds a new `getWorkspaces()` method to retrieve all workspaces for the authenticated user via the Sync API. Also refactors Sync API error handling to eliminate code duplication.

## Changes

### New Feature: `getWorkspaces()` Method
- Fetches all workspaces using the Sync API with `sync_token: '*'` and `resource_types: ['workspaces']`
- Returns an array of `Workspace` objects with comprehensive type definitions
- Supports both BUSINESS and STARTER workspace plans
- Automatically converts snake_case API responses to camelCase
- Handles workspaces with and without logos

### New Types
- `Workspace` - Main workspace entity with Zod validation
- `WorkspacePlan` - BUSINESS | STARTER
- `WorkspaceLimits` - Flexible limits structure with `current` and `next` fields
- `WorkspaceProperties` - Flexible properties object
- Enhanced `SyncRequest` and `SyncResponse` types to support both read and write operations

### Refactoring: Centralized Sync Request Handling
- Added private `requestSync()` helper method to eliminate duplicate Sync API error handling code
- Updated both `getWorkspaces()` and `moveTasks()` to use the new helper
- Reduced ~20 lines of duplicated code per method to a single line

## API Usage

```typescript
import { TodoistApi, Workspace } from '@doist/todoist-api-typescript'

const api = new TodoistApi('your-token')

// Get all workspaces
const workspaces = await api.getWorkspaces()

workspaces.forEach(workspace => {
  console.log(`${workspace.name} (${workspace.plan}) - Role: ${workspace.role}`)
  console.log(`Max Projects: ${workspace.limits.current?.maxProjects}`)
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)