### PR TITLE
fix: make multipart upload browser-compatible for Vite builds

### DIFF
--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -572,10 +572,10 @@ export type UploadFileArgs = {
      * - ReadableStream: File content as a stream (requires fileName)
      * - string: Path to a file on the filesystem (fileName is optional, will be inferred from path)
      */
-    file: Buffer | NodeJS.ReadableStream | string
+    file: Buffer | NodeJS.ReadableStream | string | Blob
     /**
      * The name of the file. Required for Buffer and Stream inputs.
-     * Optional for file path strings (will be inferred from the path if not provided).
+     * Optional for file path strings and File objects (will be inferred if not provided).
      */
     fileName?: string
     /**
@@ -680,7 +680,7 @@ export type WorkspaceLogoArgs = {
     /**
      * The image file to upload (Buffer, Stream, or file path).
      */
-    file?: Buffer | NodeJS.ReadableStream | string
+    file?: Buffer | NodeJS.ReadableStream | string | Blob
     /**
      * The file name (required for Buffer/Stream uploads).
      */


### PR DESCRIPTION
## Summary

- Removes static Node-only imports (`form-data`, `fs`, `path`) from `multipart-upload.ts` that caused Vite production builds to fail with `"basename" is not exported by "__vite-browser-external"`
- Adds dual browser/Node code paths: browser uses native `FormData` with `Blob`/`File`, Node dynamically imports packages at runtime
- Extends `file` type on `UploadFileArgs` and `WorkspaceLogoArgs` to accept `Blob` alongside existing Node types

## Test plan

- [x] All 269 SDK tests pass (`npx jest`)
- [x] ESLint clean
- [x] Prettier formatting clean
- [ ] Verify Vite frontend build no longer hits `__vite-browser-external` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)