### PR TITLE
feat: Add missing Sync API commands: reminder_update, user_settings_update, update_goals

### DIFF
--- a/src/types/sync/commands/index.ts
+++ b/src/types/sync/commands/index.ts
@@ -53,7 +53,7 @@ import type {
     NoteReactionAddArgs,
     NoteReactionRemoveArgs,
 } from './notes'
-import type { ReminderAddArgs, ReminderDeleteArgs } from './reminders'
+import type { ReminderAddArgs, ReminderUpdateArgs, ReminderDeleteArgs } from './reminders'
 import type {
     WorkspaceAddArgs,
     WorkspaceUpdateArgs,
@@ -103,6 +103,8 @@ import type {
     DeleteCollaboratorArgs,
     IdMappingArgs,
     SuggestionDeleteArgs,
+    UserSettingsUpdateArgs,
+    UpdateGoalsArgs,
 } from './others'
 
 /**
@@ -176,6 +178,7 @@ export type SyncCommandsMap = {
 
     // Reminders
     reminder_add: ReminderAddArgs
+    reminder_update: ReminderUpdateArgs
     reminder_delete: ReminderDeleteArgs
 
     // Workspaces
@@ -233,6 +236,8 @@ export type SyncCommandsMap = {
 
     // Others
     user_update: UserUpdateArgs
+    user_settings_update: UserSettingsUpdateArgs
+    update_goals: UpdateGoalsArgs
     delete_collaborator: DeleteCollaboratorArgs
     id_mapping: IdMappingArgs
     suggestion_delete: SuggestionDeleteArgs

--- a/src/types/sync/commands/others.ts
+++ b/src/types/sync/commands/others.ts
@@ -15,3 +15,19 @@ export type IdMappingArgs = {
 export type SuggestionDeleteArgs = {
     type: 'templates'
 }
+
+export type UserSettingsUpdateArgs = {
+    reminderPush?: boolean
+    reminderDesktop?: boolean
+    reminderEmail?: boolean
+    completedSoundDesktop?: boolean
+    completedSoundMobile?: boolean
+}
+
+export type UpdateGoalsArgs = {
+    dailyGoal?: number
+    weeklyGoal?: number
+    ignoreDays?: number[]
+    vacationMode?: 0 | 1
+    karmaDisabled?: 0 | 1
+}

--- a/src/types/sync/commands/reminders.ts
+++ b/src/types/sync/commands/reminders.ts
@@ -27,6 +27,20 @@ export type ReminderAddArgs =
           notifyUid?: string
       }
 
+export type ReminderUpdateArgs = {
+    id: string
+    notifyUid?: string
+    type?: 'relative' | 'absolute' | 'location'
+    due?: SyncDueDate
+    minuteOffset?: number
+    name?: string
+    locLat?: string
+    locLong?: string
+    locTrigger?: 'on_enter' | 'on_leave'
+    radius?: number
+    isDeleted?: boolean
+}
+
 export type ReminderDeleteArgs = {
     id: string
 }


### PR DESCRIPTION
## Summary
- Add `ReminderUpdateArgs` type for the `reminder_update` Sync API command
- Add `UserSettingsUpdateArgs` type for the `user_settings_update` Sync API command
- Add `UpdateGoalsArgs` type for the `update_goals` Sync API command
- Register all three in `SyncCommandsMap` for full type safety

These commands are documented in the [v1 API docs](https://developer.todoist.com/api/v1/) but were missing from the SDK.

## Test plan
- [x] `npm run build` compiles successfully
- [x] All existing tests pass (347/347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)