### PR TITLE
fix!: correct color keys to match backend (turquoise→teal, gray→grey)

### DIFF
--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -184,12 +184,6 @@ export const colors = [
     taupe,
 ] as const
 
-/** @deprecated Use {@link teal} instead. Will be removed in the next major version. */
-export const turquoise = teal
-
-/** @deprecated Use {@link grey} instead. Will be removed in the next major version. */
-export const gray = grey
-
 export type ColorKey = (typeof colors)[number]['key']
 
 export const defaultColor: Color = charcoal


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR renames two color keys to match the Todoist backend. The old keys (`turquoise`, `gray`) were never accepted by the API and caused `INVALID_COLOR` errors at runtime.

| Before (broken) | After (correct) | Color ID |
|---|---|---|
| `turquoise` | `teal` | 38 |
| `gray` | `grey` | 48 |

### Migration

Replace any usage of the old color keys:
- `'turquoise'` → `'teal'`
- `'gray'` → `'grey'`
- `import { turquoise }` → `import { teal }`
- `import { gray }` → `import { grey }`

## Summary

- The SDK defined color keys `turquoise` (id 38) and `gray` (id 48) which don't exist in the Todoist backend — both the REST and Sync APIs expect `teal` and `grey` respectively
- Sending the old keys resulted in `INVALID_COLOR` errors at runtime
- Renamed the color constants and keys to match the backend, with no deprecated aliases

Related: [Doist/todoist-ai#357](https://github.com/Doist/todoist-ai/pull/357) worked around this with a per-tool color remap that can be removed once this fix is released.

## Test plan

- [x] All 372 existing tests pass
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] `ColorKey` type now includes `'teal'` and `'grey'` instead of `'turquoise'` and `'gray'`
- [ ] Verify projects/labels/filters can be created with `color: 'teal'` and `color: 'grey'` against the live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)