### PR TITLE
test: add tests for createCommand and api.sync()

### DIFF
--- a/src/todoist-api.sync.test.ts
+++ b/src/todoist-api.sync.test.ts
@@ -1,0 +1,69 @@
+import { TodoistApi } from '.'
+import { createCommand } from './utils/sync-helpers'
+import { DEFAULT_AUTH_TOKEN } from './test-utils/test-defaults'
+import { getSyncBaseUri, ENDPOINT_SYNC } from './consts/endpoints'
+import { server, http, HttpResponse } from './test-utils/msw-setup'
+
+function getTarget() {
+    return new TodoistApi(DEFAULT_AUTH_TOKEN)
+}
+
+describe('TodoistApi sync endpoint', () => {
+    describe('sync', () => {
+        test('returns a sync response', async () => {
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_SYNC}`, () => {
+                    return HttpResponse.json({ syncToken: 'token123' }, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            const response = await api.sync({
+                commands: [createCommand('item_add', { content: 'Buy milk' })],
+                resourceTypes: ['items'],
+                syncToken: '*',
+            })
+
+            expect(response.syncToken).toBe('token123')
+        })
+
+        test('sends the command type and args in the request body', async () => {
+            let capturedBody: { commands: Array<{ type: string; args: unknown }> } | undefined
+
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_SYNC}`, async ({ request }) => {
+                    capturedBody = await request.json()
+                    return HttpResponse.json({ syncToken: 'token123' }, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.sync({
+                commands: [createCommand('item_add', { content: 'Buy milk' })],
+                syncToken: '*',
+            })
+
+            expect(capturedBody).toBeDefined()
+            expect(capturedBody?.commands[0].type).toBe('item_add')
+            expect(capturedBody?.commands[0].args).toEqual({ content: 'Buy milk' })
+        })
+
+        test('rejects invalid command name in sync request at compile time', async () => {
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_SYNC}`, () => {
+                    return HttpResponse.json({}, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.sync({
+                commands: [
+                    // @ts-expect-error invalid command name
+                    createCommand('task_add', { name: 'Buy milk' }),
+                ],
+                resourceTypes: ['items'],
+                syncToken: '*',
+            })
+        })
+    })
+})

--- a/src/utils/sync-helpers.test.ts
+++ b/src/utils/sync-helpers.test.ts
@@ -1,0 +1,45 @@
+import { createCommand } from './sync-helpers'
+
+describe('createCommand', () => {
+    test('sets the correct type', () => {
+        const cmd = createCommand('item_add', { content: 'Buy milk' })
+        expect(cmd.type).toBe('item_add')
+    })
+
+    test('auto-generates a UUID', () => {
+        const cmd = createCommand('item_add', { content: 'Buy milk' })
+        expect(cmd.uuid).toMatch(/^[0-9a-f-]{36}$/)
+    })
+
+    test('generates unique UUIDs per invocation', () => {
+        const cmd1 = createCommand('item_add', { content: 'Buy milk' })
+        const cmd2 = createCommand('item_add', { content: 'Buy milk' })
+        expect(cmd1.uuid).not.toBe(cmd2.uuid)
+    })
+
+    test('passes args through correctly', () => {
+        const args = { content: 'Buy milk', priority: 2 }
+        const cmd = createCommand('item_add', args)
+        expect(cmd.args).toEqual(args)
+    })
+
+    test('includes tempId when provided', () => {
+        const cmd = createCommand('item_add', { content: 'Buy milk' }, 'temp-123')
+        expect(cmd.tempId).toBe('temp-123')
+    })
+
+    test('omits tempId when not provided', () => {
+        const cmd = createCommand('item_add', { content: 'Buy milk' })
+        expect(cmd).not.toHaveProperty('tempId')
+    })
+
+    test('rejects invalid command name at compile time', () => {
+        // @ts-expect-error 'task_add' is not a valid SyncCommandType
+        createCommand('task_add', { content: 'Buy milk' })
+    })
+
+    test('rejects invalid args shape at compile time', () => {
+        // @ts-expect-error 'content' is required for item_add
+        createCommand('item_add', {})
+    })
+})


### PR DESCRIPTION
## Summary

- Adds unit tests for `createCommand` covering runtime behaviour (type, UUID generation, args, tempId) and compile-time type-safety via `@ts-expect-error`
- Adds integration tests for `api.sync()` verifying the response shape and request body contents
- Includes a `@ts-expect-error` guard for invalid command names in a real sync call, matching the suggestion in #464

## Test plan

- [ ] `npx jest sync-helpers` — all 8 tests pass
- [ ] `npx jest todoist-api.sync` — all 3 tests pass
- [ ] Type errors on `@ts-expect-error` lines cause test failures if types drift

Closes the test gap raised in #464 (comment r2875011336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)