### PR TITLE
feat(tasks): expose order field in updateTask, mapped to child_order

### DIFF
--- a/src/todoist-api.tasks.test.ts
+++ b/src/todoist-api.tasks.test.ts
@@ -228,6 +228,37 @@ describe('TodoistApi task endpoints', () => {
             expect(response.due).toBeNull()
         })
 
+        test('remaps order to child_order in payload', async () => {
+            const returnedTask = { ...DEFAULT_TASK }
+
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_TASKS}/123`, async ({ request }) => {
+                    const body = (await request.json()) as Record<string, unknown>
+                    expect(body.child_order).toBe(3)
+                    expect(body.order).toBeUndefined()
+                    return HttpResponse.json(returnedTask, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.updateTask('123', { order: 3 })
+        })
+
+        test('does not send child_order when order is not provided', async () => {
+            const returnedTask = { ...DEFAULT_TASK }
+
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_TASKS}/123`, async ({ request }) => {
+                    const body = (await request.json()) as Record<string, unknown>
+                    expect(body.child_order).toBeUndefined()
+                    return HttpResponse.json(returnedTask, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.updateTask('123', { content: 'some content' })
+        })
+
         test('keeps deadlineDate null in payload', async () => {
             const returnedTask = {
                 ...DEFAULT_TASK,

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -595,13 +595,18 @@ export class TodoistApi {
                   }
                 : normalizedArgs
 
+        // Remap `order` → `childOrder` so snakeCaseKeys() produces `child_order`
+        const { order, ...argsWithoutOrder } = processedArgs
+        const remappedArgs =
+            order !== undefined ? { ...argsWithoutOrder, childOrder: order } : argsWithoutOrder
+
         const response = await request<Task>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
             relativePath: generatePath(ENDPOINT_REST_TASKS, id),
             apiToken: this.authToken,
             customFetch: this.customFetch,
-            payload: processedArgs,
+            payload: remappedArgs,
             requestId: requestId,
         })
 

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -139,6 +139,11 @@ export type UpdateTaskArgs = {
     labels?: string[]
     priority?: number
     /**
+     * Sort order of the task within its parent/project.
+     * Internally mapped to `child_order` in the API payload.
+     */
+    order?: number
+    /**
      * Natural language due date.
      * Use `"no date"` to clear a due date, or `null` as an SDK alias for the same behavior.
      */


### PR DESCRIPTION
## Summary

- Adds `order?: number` to `UpdateTaskArgs` with a JSDoc note explaining the internal mapping
- Remaps `order` → `childOrder` in `updateTask` before sending the payload so `snakeCaseKeys()` produces `child_order` as required by the Todoist REST API
- Adds two tests covering the remap and the no-op case

## Test plan

- [x] `npm test -- --testPathPatterns=tasks` — all 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)