### PR TITLE
fix(projects): add workspaceId to AddProjectArgs

### DIFF
--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -250,6 +250,7 @@ export type AddProjectArgs = {
     color?: ColorKey
     isFavorite?: boolean
     viewStyle?: ProjectViewStyle
+    workspaceId?: string
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `workspaceId` field to `AddProjectArgs` type so SDK consumers can create workspace projects via the REST API `addProject()` method
- The backend already supports this parameter; this aligns the SDK with the existing API

## Test plan
- [x] All 363 existing tests pass
- [ ] Verify creating a workspace project via `addProject({ name: "test", workspaceId: "123" })` works against the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)