### PR TITLE
feat: add workspace user management endpoints

### DIFF
--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -88,15 +88,15 @@ export function getWorkspaceInvitationRejectEndpoint(inviteCode: string): string
 export const ENDPOINT_WORKSPACE_MEMBERS = 'workspaces/members'
 
 // Workspace user management (require workspace_id and/or user_id parameters)
-export function getWorkspaceUserTasksEndpoint(workspaceId: number, userId: number): string {
+export function getWorkspaceUserTasksEndpoint(workspaceId: string, userId: string): string {
     return `workspaces/${workspaceId}/users/${userId}/tasks`
 }
 
-export function getWorkspaceInviteUsersEndpoint(workspaceId: number): string {
+export function getWorkspaceInviteUsersEndpoint(workspaceId: string): string {
     return `workspaces/${workspaceId}/users/invite`
 }
 
-export function getWorkspaceUserEndpoint(workspaceId: number, userId: number): string {
+export function getWorkspaceUserEndpoint(workspaceId: string, userId: string): string {
     return `workspaces/${workspaceId}/users/${userId}`
 }
 

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -14,7 +14,6 @@ import {
     WorkspacePlanDetails,
     JoinWorkspaceResult,
     Workspace,
-    WorkspaceUserView,
 } from './types/entities'
 import { LOCATION_TRIGGERS } from './types/sync/resources/reminders'
 import {
@@ -182,7 +181,6 @@ import {
     validateWorkspaceArray,
     validateMemberActivityInfoArray,
     validateWorkspaceUserTaskArray,
-    validateWorkspaceUserView,
 } from './utils/validators'
 import { formatDateToYYYYMMDD } from './utils/url-helpers'
 import { uploadMultipartFile } from './utils/multipart-upload'
@@ -2672,9 +2670,9 @@ export class TodoistApi {
     async updateWorkspaceUser(
         args: UpdateWorkspaceUserArgs,
         requestId?: string,
-    ): Promise<WorkspaceUserView> {
+    ): Promise<JoinWorkspaceResult> {
         const { workspaceId, userId, ...payload } = args
-        const response = await request<WorkspaceUserView>({
+        const response = await request<JoinWorkspaceResult>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
             relativePath: getWorkspaceUserEndpoint(workspaceId, userId),
@@ -2683,7 +2681,7 @@ export class TodoistApi {
             payload: payload,
             requestId: requestId,
         })
-        return validateWorkspaceUserView(response.data)
+        return validateJoinWorkspaceResult(response.data)
     }
 
     /**

--- a/src/todoist-api.workspaces.test.ts
+++ b/src/todoist-api.workspaces.test.ts
@@ -641,8 +641,8 @@ describe('TodoistApi workspaces', () => {
         test('gets workspace members activity', async () => {
             const mockResponse = {
                 members: [
-                    { userId: '123', tasksAssigned: 5, tasksOverdue: 2 },
-                    { userId: '456', tasksAssigned: 3, tasksOverdue: 0 },
+                    { user_id: '123', tasks_assigned: 5, tasks_overdue: 2 },
+                    { user_id: '456', tasks_assigned: 3, tasks_overdue: 0 },
                 ],
             }
             server.use(
@@ -651,7 +651,7 @@ describe('TodoistApi workspaces', () => {
                 }),
             )
 
-            const result = await api.getWorkspaceMembersActivity({ workspaceId: 123 })
+            const result = await api.getWorkspaceMembersActivity({ workspaceId: '123' })
 
             expect(result.members).toHaveLength(2)
             expect(result.members[0]).toMatchObject({
@@ -669,16 +669,16 @@ describe('TodoistApi workspaces', () => {
                     {
                         id: '1',
                         content: 'Test task',
-                        responsibleUid: '123',
+                        responsible_uid: '123',
                         due: null,
                         deadline: null,
                         labels: ['work'],
-                        notesCount: 0,
-                        projectId: 'proj1',
-                        projectName: 'Project 1',
+                        notes_count: 0,
+                        project_id: 'proj1',
+                        project_name: 'Project 1',
                         priority: 1,
                         description: '',
-                        isOverdue: false,
+                        is_overdue: false,
                     },
                 ],
             }
@@ -689,8 +689,8 @@ describe('TodoistApi workspaces', () => {
             )
 
             const result = await api.getWorkspaceUserTasks({
-                workspaceId: 123,
-                userId: 456,
+                workspaceId: '123',
+                userId: '456',
             })
 
             expect(result.tasks).toHaveLength(1)
@@ -704,7 +704,7 @@ describe('TodoistApi workspaces', () => {
     describe('inviteWorkspaceUsers', () => {
         test('invites users to a workspace', async () => {
             const mockResponse = {
-                invitedEmails: ['user1@example.com', 'user2@example.com'],
+                invited_emails: ['user1@example.com', 'user2@example.com'],
             }
             server.use(
                 http.post(`${getSyncBaseUri()}workspaces/123/users/invite`, () => {
@@ -713,7 +713,7 @@ describe('TodoistApi workspaces', () => {
             )
 
             const result = await api.inviteWorkspaceUsers({
-                workspaceId: 123,
+                workspaceId: '123',
                 emailList: ['user1@example.com', 'user2@example.com'],
             })
 
@@ -724,11 +724,11 @@ describe('TodoistApi workspaces', () => {
     describe('updateWorkspaceUser', () => {
         test('updates a workspace user role', async () => {
             const mockResponse = {
-                userId: '456',
-                workspaceId: '123',
+                user_id: '456',
+                workspace_id: '123',
                 role: 'ADMIN',
-                customSortingApplied: false,
-                projectSortPreference: 'MANUAL',
+                custom_sorting_applied: false,
+                project_sort_preference: 'MANUAL',
             }
             server.use(
                 http.post(`${getSyncBaseUri()}workspaces/123/users/456`, () => {
@@ -737,8 +737,8 @@ describe('TodoistApi workspaces', () => {
             )
 
             const result = await api.updateWorkspaceUser({
-                workspaceId: 123,
-                userId: 456,
+                workspaceId: '123',
+                userId: '456',
                 role: 'ADMIN',
             })
 
@@ -759,8 +759,8 @@ describe('TodoistApi workspaces', () => {
             )
 
             const result = await api.removeWorkspaceUser({
-                workspaceId: 123,
-                userId: 456,
+                workspaceId: '123',
+                userId: '456',
             })
 
             expect(result).toEqual(true)

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -713,20 +713,3 @@ export const WorkspaceUserTaskSchema = z.object({
  * Represents a task assigned to a workspace user.
  */
 export type WorkspaceUserTask = z.infer<typeof WorkspaceUserTaskSchema>
-
-/** Available workspace project sort preferences. */
-export const PROJECT_SORT_PREFERENCES = ['MANUAL', 'ALPHABETICAL'] as const
-/** Sort preference for projects in a workspace. */
-export type ProjectSortPreference = (typeof PROJECT_SORT_PREFERENCES)[number]
-
-export const WorkspaceUserViewSchema = z.object({
-    userId: z.string(),
-    workspaceId: z.string(),
-    role: WorkspaceRoleSchema,
-    customSortingApplied: z.boolean().default(false),
-    projectSortPreference: z.enum(PROJECT_SORT_PREFERENCES).default('MANUAL'),
-})
-/**
- * Represents a workspace user view (returned from user management endpoints).
- */
-export type WorkspaceUserView = z.infer<typeof WorkspaceUserViewSchema>

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -819,7 +819,7 @@ export type UpdateWorkspaceArgs = {
  */
 export type GetWorkspaceMembersActivityArgs = {
     /** The workspace ID. */
-    workspaceId: number
+    workspaceId: string
     /** Comma-separated list of user IDs to filter by. */
     userIds?: string | null
     /** Comma-separated list of project IDs to filter by. */
@@ -839,9 +839,9 @@ export type GetWorkspaceMembersActivityResponse = {
  */
 export type GetWorkspaceUserTasksArgs = {
     /** The workspace ID. */
-    workspaceId: number
+    workspaceId: string
     /** The user ID. */
-    userId: number
+    userId: string
     /** Comma-separated list of project IDs to filter by. */
     projectIds?: string | null
 }
@@ -859,7 +859,7 @@ export type GetWorkspaceUserTasksResponse = {
  */
 export type InviteWorkspaceUsersArgs = {
     /** The workspace ID. */
-    workspaceId: number
+    workspaceId: string
     /** List of user emails to invite. */
     emailList: string[]
     /** Role assigned to invited users. */
@@ -879,9 +879,9 @@ export type InviteWorkspaceUsersResponse = {
  */
 export type UpdateWorkspaceUserArgs = {
     /** The workspace ID. */
-    workspaceId: number
+    workspaceId: string
     /** The user ID. */
-    userId: number
+    userId: string
     /** Updated role for the user. */
     role: WorkspaceRole
 }
@@ -892,9 +892,9 @@ export type UpdateWorkspaceUserArgs = {
  */
 export type RemoveWorkspaceUserArgs = {
     /** The workspace ID. */
-    workspaceId: number
+    workspaceId: string
     /** The user ID. */
-    userId: number
+    userId: string
 }
 
 /**

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -22,7 +22,6 @@ import {
     WorkspaceSchema,
     MemberActivityInfoSchema,
     WorkspaceUserTaskSchema,
-    WorkspaceUserViewSchema,
 } from '../types/entities'
 
 import {
@@ -144,8 +143,6 @@ export const validateMemberActivityInfoArray = createArrayValidator(validateMemb
 
 export const validateWorkspaceUserTask = createValidator(WorkspaceUserTaskSchema)
 export const validateWorkspaceUserTaskArray = createArrayValidator(validateWorkspaceUserTask)
-
-export const validateWorkspaceUserView = createValidator(WorkspaceUserViewSchema)
 
 // Sync resource validators
 


### PR DESCRIPTION
## Summary
- Add `getWorkspaceMembersActivity(args)` to retrieve activity stats for workspace members
- Add `getWorkspaceUserTasks(args)` to get tasks assigned to a specific workspace user
- Add `inviteWorkspaceUsers(args)` to invite users to a workspace by email
- Add `updateWorkspaceUser(args)` to update a workspace user's role
- Add `removeWorkspaceUser(args)` to remove a user from a workspace
- New entity types: `MemberActivityInfo`, `WorkspaceUserTask`, `WorkspaceUserView`, `ProjectSortPreference`

## Test plan
- [x] All 5 new endpoints have corresponding tests
- [x] Full test suite passes (422 tests)
- [x] Build compiles successfully
- [x] Prettier + oxlint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)