### PR TITLE
fix: move types condition before import/require in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "types": "dist/types/index.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/types/index.d.ts",
             "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js",
-            "types": "./dist/types/index.d.ts"
+            "require": "./dist/cjs/index.js"
         }
     },
     "sideEffects": false,


### PR DESCRIPTION
## Summary
- Reorders the `exports` conditions in `package.json` so `types` comes before `import` and `require`
- Fixes the bundler warning about the `types` condition never being reached

## Test plan
- [ ] Verify the warning no longer appears when bundling
- [ ] Confirm TypeScript type resolution still works for consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)