### PR TITLE
chore: use GitHub App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,17 @@ jobs:
               with:
                   app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
                   private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
+                  permissions: contents:write, issues:write, pull-requests:write
 
             - name: Get bot user ID
               id: bot_user
-              run: echo "id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+              run: |
+                  user_id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)
+                  if [ -z "$user_id" ]; then
+                      echo "Failed to get bot user ID" >&2
+                      exit 1
+                  fi
+                  echo "id=$user_id" >> "$GITHUB_OUTPUT"
               env:
                   GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
## Summary
Replace `GH_REPO_TOKEN` (PAT) with a dynamically generated short-lived token from the `doist-release-bot` GitHub App via `actions/create-github-app-token@v1`.

## Changes
- Add `Generate bot token` step using `actions/create-github-app-token@v1`
- Add `Get bot user ID` step to derive the bot's noreply email address
- Replace `secrets.GH_REPO_TOKEN` with the generated token
- Replace hardcoded Doist Bot identity with dynamic identity from the GitHub App

## Pre-merge checklist
- [ ] `DOIST_RELEASE_BOT_ID` and `DOIST_RELEASE_BOT_PRIVATE_KEY` secrets are configured
- [ ] `doist-release-bot` app is installed on this repo and added as bypass actor on the branch ruleset

Part of https://github.com/Doist/todoist-web/issues/16941

🤖 Generated with [Claude Code](https://claude.com/claude-code)