### PR TITLE
chore: use individual permission inputs for create-github-app-token v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
               with:
                   app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
                   private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
-                  permissions: contents:write, issues:write, pull-requests:write
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
 
             - name: Get bot user ID
               id: bot_user


### PR DESCRIPTION
## Summary
v3 of `actions/create-github-app-token` uses individual `permission-*` inputs instead of the single `permissions` input from v1.

Part of https://github.com/Doist/todoist-web/issues/16941

🤖 Generated with [Claude Code](https://claude.com/claude-code)