### PR TITLE
fix: align WorkspaceSchema with actual REST API response

### DIFF
--- a/src/todoist-api.workspaces.test.ts
+++ b/src/todoist-api.workspaces.test.ts
@@ -579,7 +579,7 @@ describe('TodoistApi workspaces', () => {
                 name: 'Numeric ID Workspace',
                 plan: 'BUSINESS',
                 creatorId: '499807',
-                dateCreated: '2022-08-16T11:16:22.433711Z',
+                createdAt: '2022-08-16T11:16:22.433711Z',
             })
             // id and creatorId should be strings after coercion
             expect(typeof result[0].id).toBe('string')
@@ -612,8 +612,8 @@ describe('TodoistApi workspaces', () => {
             expect(result).toHaveLength(1)
             expect(result[0].role).toBeUndefined()
             expect(result[0].limits).toBeUndefined()
-            expect(result[0].createdAt).toBeUndefined()
-            expect(result[0].dateCreated).toBe('2023-06-01T00:00:00Z')
+            // dateCreated from the API is normalized to createdAt
+            expect(result[0].createdAt).toBe('2023-06-01T00:00:00Z')
         })
 
         test('validates workspace schema', async () => {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,7 +1,16 @@
+import { z } from 'zod'
+
 type SearchArgs = {
     query: string
     cursor?: string | null
     limit?: number
 }
 
+/**
+ * Zod schema that accepts both string and number values and coerces to string.
+ * The REST API returns numeric IDs while the Sync API returns string IDs.
+ */
+const StringOrNumberSchema = z.union([z.string(), z.number()]).transform((val) => String(val))
+
+export { StringOrNumberSchema }
 export type { SearchArgs }

--- a/src/types/sync/resources/workspaces.ts
+++ b/src/types/sync/resources/workspaces.ts
@@ -1,16 +1,11 @@
 import { z } from 'zod'
+import { StringOrNumberSchema } from '../../common'
 import {
     WorkspaceRoleSchema,
     WorkspacePlanSchema,
     WorkspaceLimitsSchema,
     WorkspacePropertiesSchema,
 } from '../../workspaces/types'
-
-/**
- * Coerces a string or number value to a string.
- * The REST API returns numeric IDs while the Sync API returns string IDs.
- */
-const stringOrNumber = z.union([z.string(), z.number()]).transform((val) => String(val))
 
 /**
  * Sync API workspace resource.
@@ -21,21 +16,21 @@ const stringOrNumber = z.union([z.string(), z.number()]).transform((val) => Stri
  */
 export const SyncWorkspaceSchema = z
     .object({
-        id: stringOrNumber,
+        id: StringOrNumberSchema,
         name: z.string(),
         description: z.string(),
         logoBig: z.string().optional(),
         logoMedium: z.string().optional(),
         logoSmall: z.string().optional(),
         logoS640: z.string().optional(),
-        creatorId: stringOrNumber,
+        creatorId: StringOrNumberSchema,
         createdAt: z.string().optional(),
         dateCreated: z.string().optional(),
         isDeleted: z.boolean(),
         isCollapsed: z.boolean(),
-        role: WorkspaceRoleSchema,
+        role: WorkspaceRoleSchema.optional(),
         plan: WorkspacePlanSchema,
-        limits: WorkspaceLimitsSchema,
+        limits: WorkspaceLimitsSchema.optional(),
         inviteCode: z.string().nullable().optional(),
         isLinkSharingEnabled: z.boolean().nullable().optional(),
         isGuestAllowed: z.boolean().nullable().optional(),
@@ -64,5 +59,9 @@ export const SyncWorkspaceSchema = z
         properties: WorkspacePropertiesSchema.optional(),
     })
     .passthrough()
+    .transform(({ dateCreated, createdAt, ...rest }) => ({
+        ...rest,
+        createdAt: createdAt ?? dateCreated,
+    }))
 
 export type SyncWorkspace = z.infer<typeof SyncWorkspaceSchema>

--- a/src/types/workspaces/types.ts
+++ b/src/types/workspaces/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { StringOrNumberSchema } from '../common'
 import { DueDateSchema, DeadlineSchema } from '../tasks/types'
 
 /** Available project collaborator roles. */
@@ -159,32 +160,31 @@ export const WorkspacePropertiesSchema = z.record(z.string(), z.unknown())
 export type WorkspaceProperties = z.infer<typeof WorkspacePropertiesSchema>
 
 /**
- * Coerces a string or number value to a string.
- * The REST API returns numeric IDs while the Sync API returns string IDs.
- */
-const stringOrNumber = z.union([z.string(), z.number()]).transform((val) => String(val))
-
-/**
  * Represents a workspace in Todoist.
  */
-export const WorkspaceSchema = z.object({
-    id: stringOrNumber,
-    name: z.string(),
-    plan: WorkspacePlanSchema,
-    role: WorkspaceRoleSchema.optional(),
-    inviteCode: z.string(),
-    isLinkSharingEnabled: z.boolean(),
-    isGuestAllowed: z.boolean(),
-    limits: WorkspaceLimitsSchema.optional(),
-    logoBig: z.string().nullish(),
-    logoMedium: z.string().nullish(),
-    logoSmall: z.string().nullish(),
-    logoS640: z.string().nullish(),
-    createdAt: z.string().optional(),
-    dateCreated: z.string().optional(),
-    creatorId: stringOrNumber,
-    properties: WorkspacePropertiesSchema,
-})
+export const WorkspaceSchema = z
+    .object({
+        id: StringOrNumberSchema,
+        name: z.string(),
+        plan: WorkspacePlanSchema,
+        role: WorkspaceRoleSchema.optional(),
+        inviteCode: z.string(),
+        isLinkSharingEnabled: z.boolean(),
+        isGuestAllowed: z.boolean(),
+        limits: WorkspaceLimitsSchema.optional(),
+        logoBig: z.string().nullish(),
+        logoMedium: z.string().nullish(),
+        logoSmall: z.string().nullish(),
+        logoS640: z.string().nullish(),
+        createdAt: z.string().optional(),
+        dateCreated: z.string().optional(),
+        creatorId: StringOrNumberSchema,
+        properties: WorkspacePropertiesSchema,
+    })
+    .transform(({ dateCreated, createdAt, ...rest }) => ({
+        ...rest,
+        createdAt: createdAt ?? dateCreated,
+    }))
 
 export type Workspace = z.infer<typeof WorkspaceSchema>
 


### PR DESCRIPTION
## Summary

- The Todoist REST API returns numeric `id` and `creator_id` for workspaces, uses `date_created` instead of `created_at`, and omits `role` and `limits` fields entirely
- The Zod `WorkspaceSchema` expected string IDs and required all fields, causing `ZodError` validation failures on `getWorkspaces()` and related methods
- Coerce `id`/`creatorId` to accept both string and number (following the existing `ActivityEventSchema` pattern in `src/types/activity/types.ts`)
- Make `role`, `limits`, and `createdAt` optional; add `dateCreated` field
- Apply same fixes to `SyncWorkspaceSchema`

Related: Doist/todoist-ai#426

## Test plan

- [x] New tests for numeric ID coercion (verified string output from number input)
- [x] New tests for missing `role`, `limits`, and `createdAt` fields
- [x] All 455 existing tests pass
- [x] Verified live against real API — `list-workspaces` returns all workspaces successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)