### PR TITLE
refactor: Extract ReminderClient, InsightsClient, and FolderClient

### DIFF
--- a/src/clients/folder-client.ts
+++ b/src/clients/folder-client.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+import { ENDPOINT_REST_FOLDERS } from '../consts/endpoints'
+import { isSuccess, request } from '../transport/http-client'
+import type {
+    AddFolderArgs,
+    GetFoldersArgs,
+    GetFoldersResponse,
+    UpdateFolderArgs,
+} from '../types/folders'
+import type { Folder } from '../types/sync/resources/folders'
+import { generatePath } from '../utils/request-helpers'
+import { validateFolder, validateFolderArray } from '../utils/validators'
+import { BaseClient } from './base-client'
+
+/**
+ * Internal sub-client handling all folder-domain endpoints.
+ *
+ * Instantiated by `TodoistApi`; every public folder method on `TodoistApi`
+ * delegates here. See `todoist-api.ts` for the user-facing JSDoc.
+ */
+export class FolderClient extends BaseClient {
+    async getFolders(args: GetFoldersArgs): Promise<GetFoldersResponse> {
+        const {
+            data: { results, nextCursor },
+        } = await request<GetFoldersResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_FOLDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+        })
+
+        return {
+            results: validateFolderArray(results),
+            nextCursor,
+        }
+    }
+
+    async getFolder(id: string): Promise<Folder> {
+        z.string().parse(id)
+        const response = await request<Folder>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+        })
+
+        return validateFolder(response.data)
+    }
+
+    async addFolder(args: AddFolderArgs, requestId?: string): Promise<Folder> {
+        const response = await request<Folder>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_FOLDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+            requestId: requestId,
+        })
+
+        return validateFolder(response.data)
+    }
+
+    async updateFolder(id: string, args: UpdateFolderArgs, requestId?: string): Promise<Folder> {
+        z.string().parse(id)
+        const response = await request<Folder>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+            requestId: requestId,
+        })
+
+        return validateFolder(response.data)
+    }
+
+    async deleteFolder(id: string, requestId?: string): Promise<boolean> {
+        z.string().parse(id)
+        const response = await request({
+            httpMethod: 'DELETE',
+            baseUri: this.syncApiBase,
+            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            requestId: requestId,
+        })
+        return isSuccess(response)
+    }
+}

--- a/src/clients/insights-client.ts
+++ b/src/clients/insights-client.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+import {
+    getProjectInsightsActivityStatsEndpoint,
+    getProjectInsightsHealthAnalyzeEndpoint,
+    getProjectInsightsHealthContextEndpoint,
+    getProjectInsightsHealthEndpoint,
+    getProjectInsightsProgressEndpoint,
+    getWorkspaceInsightsEndpoint,
+} from '../consts/endpoints'
+import { request } from '../transport/http-client'
+import type {
+    GetProjectActivityStatsArgs,
+    GetWorkspaceInsightsArgs,
+    ProjectActivityStats,
+    ProjectHealth,
+    ProjectHealthContext,
+    ProjectProgress,
+    WorkspaceInsights,
+} from '../types/insights'
+import {
+    validateProjectActivityStats,
+    validateProjectHealth,
+    validateProjectHealthContext,
+    validateProjectProgress,
+    validateWorkspaceInsights,
+} from '../utils/validators'
+import { BaseClient } from './base-client'
+
+/**
+ * Internal sub-client handling all insights-domain endpoints
+ * (project activity stats, health, progress, workspace insights).
+ *
+ * Instantiated by `TodoistApi`; every public insights method on
+ * `TodoistApi` delegates here. See `todoist-api.ts` for user-facing
+ * JSDoc.
+ */
+export class InsightsClient extends BaseClient {
+    async getProjectActivityStats(
+        projectId: string,
+        args: GetProjectActivityStatsArgs = {},
+    ): Promise<ProjectActivityStats> {
+        z.string().parse(projectId)
+        const response = await request<ProjectActivityStats>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: getProjectInsightsActivityStatsEndpoint(projectId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: { objectType: 'ITEM', eventType: 'COMPLETED', ...args },
+        })
+        return validateProjectActivityStats(response.data)
+    }
+
+    async getProjectHealth(projectId: string): Promise<ProjectHealth> {
+        z.string().parse(projectId)
+        const response = await request<ProjectHealth>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: getProjectInsightsHealthEndpoint(projectId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+        })
+        return validateProjectHealth(response.data)
+    }
+
+    async getProjectHealthContext(projectId: string): Promise<ProjectHealthContext> {
+        z.string().parse(projectId)
+        const response = await request<ProjectHealthContext>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: getProjectInsightsHealthContextEndpoint(projectId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+        })
+        return validateProjectHealthContext(response.data)
+    }
+
+    async getProjectProgress(projectId: string): Promise<ProjectProgress> {
+        z.string().parse(projectId)
+        const response = await request<ProjectProgress>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: getProjectInsightsProgressEndpoint(projectId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+        })
+        return validateProjectProgress(response.data)
+    }
+
+    async getWorkspaceInsights(
+        workspaceId: string,
+        args: GetWorkspaceInsightsArgs = {},
+    ): Promise<WorkspaceInsights> {
+        z.string().parse(workspaceId)
+        const response = await request<WorkspaceInsights>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: getWorkspaceInsightsEndpoint(workspaceId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: {
+                ...args,
+                ...(args.projectIds ? { projectIds: args.projectIds.join(',') } : {}),
+            },
+        })
+        return validateWorkspaceInsights(response.data)
+    }
+
+    async analyzeProjectHealth(projectId: string, requestId?: string): Promise<ProjectHealth> {
+        z.string().parse(projectId)
+        const response = await request<ProjectHealth>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: getProjectInsightsHealthAnalyzeEndpoint(projectId),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            requestId: requestId,
+        })
+        return validateProjectHealth(response.data)
+    }
+}

--- a/src/clients/reminder-client.ts
+++ b/src/clients/reminder-client.ts
@@ -1,0 +1,260 @@
+import { ENDPOINT_REST_LOCATION_REMINDERS, ENDPOINT_REST_REMINDERS } from '../consts/endpoints'
+import { isSuccess, request } from '../transport/http-client'
+import type { Reminder } from '../types'
+import { TodoistArgumentError, TodoistRequestError } from '../types'
+import type {
+    AddLocationReminderArgs,
+    AddReminderArgs,
+    GetLocationRemindersArgs,
+    GetLocationRemindersResponse,
+    GetRemindersArgs,
+    GetRemindersResponse,
+    UpdateLocationReminderArgs,
+    UpdateReminderArgs,
+} from '../types/reminders'
+import {
+    ReminderIdSchema,
+    UpdateLocationReminderArgsSchema,
+    UpdateReminderArgsSchema,
+} from '../types/reminders'
+import { generatePath } from '../utils/request-helpers'
+import {
+    validateLocationReminderArray,
+    validateReminder,
+    validateReminderArray,
+} from '../utils/validators'
+import { BaseClient } from './base-client'
+
+/**
+ * Internal sub-client handling all reminder-domain endpoints
+ * (both time-based and location-based reminders).
+ *
+ * Instantiated by `TodoistApi`; every public reminder method on
+ * `TodoistApi` delegates here. See `todoist-api.ts` for user-facing
+ * JSDoc. The time-vs-location 404 translation is preserved here so a
+ * caller who used the wrong endpoint gets a TodoistArgumentError
+ * pointing at the correct method, rather than a bare 404.
+ */
+export class ReminderClient extends BaseClient {
+    async getReminders(args: GetRemindersArgs = {}): Promise<GetRemindersResponse> {
+        const {
+            data: { results, nextCursor },
+        } = await request<GetRemindersResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_REMINDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+        })
+        return {
+            results: validateReminderArray(results),
+            nextCursor,
+        }
+    }
+
+    async getLocationReminders(
+        args: GetLocationRemindersArgs = {},
+    ): Promise<GetLocationRemindersResponse> {
+        const {
+            data: { results, nextCursor },
+        } = await request<GetLocationRemindersResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_LOCATION_REMINDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+        })
+        return {
+            results: validateLocationReminderArray(results),
+            nextCursor,
+        }
+    }
+
+    async getReminder(id: string): Promise<Reminder> {
+        ReminderIdSchema.parse(id)
+        try {
+            const response = await request<Reminder>({
+                httpMethod: 'GET',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+            })
+
+            return validateReminder(response.data)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use getLocationReminder instead.`,
+            )
+        }
+    }
+
+    async getLocationReminder(id: string): Promise<Reminder> {
+        ReminderIdSchema.parse(id)
+        try {
+            const response = await request<Reminder>({
+                httpMethod: 'GET',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+            })
+
+            return validateReminder(response.data)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use getReminder instead.`,
+            )
+        }
+    }
+
+    async addReminder(args: AddReminderArgs, requestId?: string): Promise<Reminder> {
+        const response = await request<Reminder>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_REMINDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+            requestId: requestId,
+        })
+
+        return validateReminder(response.data)
+    }
+
+    async addLocationReminder(
+        args: AddLocationReminderArgs,
+        requestId?: string,
+    ): Promise<Reminder> {
+        const response = await request<Reminder>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_LOCATION_REMINDERS,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: {
+                ...args,
+                reminderType: 'location',
+            },
+            requestId: requestId,
+        })
+
+        return validateReminder(response.data)
+    }
+
+    async updateReminder(
+        id: string,
+        args: UpdateReminderArgs,
+        requestId?: string,
+    ): Promise<Reminder> {
+        ReminderIdSchema.parse(id)
+        const payload = UpdateReminderArgsSchema.parse(args)
+        try {
+            const response = await request<Reminder>({
+                httpMethod: 'POST',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+                payload,
+                requestId: requestId,
+            })
+
+            return validateReminder(response.data)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use updateLocationReminder instead.`,
+            )
+        }
+    }
+
+    async updateLocationReminder(
+        id: string,
+        args: UpdateLocationReminderArgs,
+        requestId?: string,
+    ): Promise<Reminder> {
+        ReminderIdSchema.parse(id)
+        const payload = UpdateLocationReminderArgsSchema.parse(args)
+        try {
+            const response = await request<Reminder>({
+                httpMethod: 'POST',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+                payload,
+                requestId: requestId,
+            })
+
+            return validateReminder(response.data)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use updateReminder instead.`,
+            )
+        }
+    }
+
+    async deleteReminder(id: string, requestId?: string): Promise<boolean> {
+        ReminderIdSchema.parse(id)
+        try {
+            const response = await request({
+                httpMethod: 'DELETE',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+                requestId: requestId,
+            })
+            return isSuccess(response)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use deleteLocationReminder instead.`,
+            )
+        }
+    }
+
+    async deleteLocationReminder(id: string, requestId?: string): Promise<boolean> {
+        ReminderIdSchema.parse(id)
+        try {
+            const response = await request({
+                httpMethod: 'DELETE',
+                baseUri: this.syncApiBase,
+                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+                requestId: requestId,
+            })
+            return isSuccess(response)
+        } catch (error) {
+            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
+                throw error
+            }
+
+            throw new TodoistArgumentError(
+                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use deleteReminder instead.`,
+            )
+        }
+    }
+}

--- a/src/clients/reminder-client.ts
+++ b/src/clients/reminder-client.ts
@@ -17,6 +17,7 @@ import {
     UpdateLocationReminderArgsSchema,
     UpdateReminderArgsSchema,
 } from '../types/reminders'
+import { ReminderTypeEnum } from '../types/sync/resources/reminders'
 import { generatePath } from '../utils/request-helpers'
 import {
     validateLocationReminderArray,
@@ -144,7 +145,7 @@ export class ReminderClient extends BaseClient {
             customFetch: this.customFetch,
             payload: {
                 ...args,
-                reminderType: 'location',
+                reminderType: ReminderTypeEnum.Location,
             },
             requestId: requestId,
         })

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod'
 import { CommentClient } from './clients/comment-client'
+import { FolderClient } from './clients/folder-client'
+import { InsightsClient } from './clients/insights-client'
 import { LabelClient } from './clients/label-client'
 import { ProjectClient } from './clients/project-client'
+import { ReminderClient } from './clients/reminder-client'
 import { SectionClient } from './clients/section-client'
 import { TaskClient } from './clients/task-client'
 import {
@@ -11,18 +14,10 @@ import {
     ENDPOINT_REST_TEMPLATES_CREATE_FROM_FILE,
     ENDPOINT_REST_TEMPLATES_IMPORT_FROM_FILE,
     ENDPOINT_REST_TEMPLATES_IMPORT_FROM_ID,
-    ENDPOINT_REST_LOCATION_REMINDERS,
-    ENDPOINT_REST_REMINDERS,
     ENDPOINT_REST_USER,
     ENDPOINT_REST_PRODUCTIVITY,
     ENDPOINT_REST_ACTIVITIES,
     ENDPOINT_REST_UPLOADS,
-    getProjectInsightsActivityStatsEndpoint,
-    getProjectInsightsHealthEndpoint,
-    getProjectInsightsHealthContextEndpoint,
-    getProjectInsightsProgressEndpoint,
-    getProjectInsightsHealthAnalyzeEndpoint,
-    getWorkspaceInsightsEndpoint,
     ENDPOINT_REST_BACKUPS,
     ENDPOINT_REST_BACKUPS_DOWNLOAD,
     ENDPOINT_REST_EMAILS,
@@ -44,7 +39,6 @@ import {
     ENDPOINT_WORKSPACE_USERS,
     getWorkspaceActiveProjectsEndpoint,
     getWorkspaceArchivedProjectsEndpoint,
-    ENDPOINT_REST_FOLDERS,
 } from './consts/endpoints'
 import { request, isSuccess } from './transport/http-client'
 import { performSyncRequest } from './transport/sync-request'
@@ -121,9 +115,6 @@ import {
     GetRemindersResponse,
     GetLocationRemindersArgs,
     GetLocationRemindersResponse,
-    UpdateReminderArgsSchema,
-    UpdateLocationReminderArgsSchema,
-    ReminderIdSchema,
 } from './types/reminders'
 import {
     Section,
@@ -208,9 +199,6 @@ import {
     validateSectionArray,
     validateTaskArray,
     validateProductivityStats,
-    validateReminder,
-    validateReminderArray,
-    validateLocationReminderArray,
     validateActivityEventArray,
     validateWorkspaceUserArray,
     validateWorkspaceInvitation,
@@ -221,19 +209,11 @@ import {
     validateWorkspaceArray,
     validateMemberActivityInfoArray,
     validateWorkspaceUserTaskArray,
-    validateProjectActivityStats,
-    validateProjectHealth,
-    validateProjectHealthContext,
-    validateProjectProgress,
-    validateWorkspaceInsights,
     validateBackupArray,
     validateIdMappingArray,
     validateMovedIdArray,
-    validateFolder,
-    validateFolderArray,
 } from './utils/validators'
 
-import { TodoistArgumentError, TodoistRequestError } from './types'
 import { type SyncResponse, type SyncRequest } from './types/sync'
 
 /**
@@ -301,6 +281,9 @@ export class TodoistApi {
     private readonly sectionClient: SectionClient
     private readonly labelClient: LabelClient
     private readonly commentClient: CommentClient
+    private readonly reminderClient: ReminderClient
+    private readonly insightsClient: InsightsClient
+    private readonly folderClient: FolderClient
 
     constructor(
         /**
@@ -332,6 +315,9 @@ export class TodoistApi {
         this.sectionClient = new SectionClient(clientDeps)
         this.labelClient = new LabelClient(clientDeps)
         this.commentClient = new CommentClient(clientDeps)
+        this.reminderClient = new ReminderClient(clientDeps)
+        this.insightsClient = new InsightsClient(clientDeps)
+        this.folderClient = new FolderClient(clientDeps)
     }
 
     /**
@@ -776,16 +762,7 @@ export class TodoistApi {
         projectId: string,
         args: GetProjectActivityStatsArgs = {},
     ): Promise<ProjectActivityStats> {
-        z.string().parse(projectId)
-        const response = await request<ProjectActivityStats>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: getProjectInsightsActivityStatsEndpoint(projectId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: { objectType: 'ITEM', eventType: 'COMPLETED', ...args },
-        })
-        return validateProjectActivityStats(response.data)
+        return this.insightsClient.getProjectActivityStats(projectId, args)
     }
 
     /**
@@ -795,15 +772,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the project health data.
      */
     async getProjectHealth(projectId: string): Promise<ProjectHealth> {
-        z.string().parse(projectId)
-        const response = await request<ProjectHealth>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: getProjectInsightsHealthEndpoint(projectId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-        })
-        return validateProjectHealth(response.data)
+        return this.insightsClient.getProjectHealth(projectId)
     }
 
     /**
@@ -813,15 +782,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the project health context.
      */
     async getProjectHealthContext(projectId: string): Promise<ProjectHealthContext> {
-        z.string().parse(projectId)
-        const response = await request<ProjectHealthContext>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: getProjectInsightsHealthContextEndpoint(projectId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-        })
-        return validateProjectHealthContext(response.data)
+        return this.insightsClient.getProjectHealthContext(projectId)
     }
 
     /**
@@ -831,15 +792,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the project progress data.
      */
     async getProjectProgress(projectId: string): Promise<ProjectProgress> {
-        z.string().parse(projectId)
-        const response = await request<ProjectProgress>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: getProjectInsightsProgressEndpoint(projectId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-        })
-        return validateProjectProgress(response.data)
+        return this.insightsClient.getProjectProgress(projectId)
     }
 
     /**
@@ -853,19 +806,7 @@ export class TodoistApi {
         workspaceId: string,
         args: GetWorkspaceInsightsArgs = {},
     ): Promise<WorkspaceInsights> {
-        z.string().parse(workspaceId)
-        const response = await request<WorkspaceInsights>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: getWorkspaceInsightsEndpoint(workspaceId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: {
-                ...args,
-                ...(args.projectIds ? { projectIds: args.projectIds.join(',') } : {}),
-            },
-        })
-        return validateWorkspaceInsights(response.data)
+        return this.insightsClient.getWorkspaceInsights(workspaceId, args)
     }
 
     /**
@@ -876,16 +817,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the updated project health data.
      */
     async analyzeProjectHealth(projectId: string, requestId?: string): Promise<ProjectHealth> {
-        z.string().parse(projectId)
-        const response = await request<ProjectHealth>({
-            httpMethod: 'POST',
-            baseUri: this.syncApiBase,
-            relativePath: getProjectInsightsHealthAnalyzeEndpoint(projectId),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            requestId: requestId,
-        })
-        return validateProjectHealth(response.data)
+        return this.insightsClient.analyzeProjectHealth(projectId, requestId)
     }
 
     // ── Sections ──
@@ -1134,20 +1066,7 @@ export class TodoistApi {
      * @returns A promise that resolves to a paginated list of reminders.
      */
     async getReminders(args: GetRemindersArgs = {}): Promise<GetRemindersResponse> {
-        const {
-            data: { results, nextCursor },
-        } = await request<GetRemindersResponse>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_REMINDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-        })
-        return {
-            results: validateReminderArray(results),
-            nextCursor,
-        }
+        return this.reminderClient.getReminders(args)
     }
 
     /**
@@ -1159,20 +1078,7 @@ export class TodoistApi {
     async getLocationReminders(
         args: GetLocationRemindersArgs = {},
     ): Promise<GetLocationRemindersResponse> {
-        const {
-            data: { results, nextCursor },
-        } = await request<GetLocationRemindersResponse>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_LOCATION_REMINDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-        })
-        return {
-            results: validateLocationReminderArray(results),
-            nextCursor,
-        }
+        return this.reminderClient.getLocationReminders(args)
     }
 
     /**
@@ -1182,26 +1088,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the requested reminder.
      */
     async getReminder(id: string): Promise<Reminder> {
-        ReminderIdSchema.parse(id)
-        try {
-            const response = await request<Reminder>({
-                httpMethod: 'GET',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-            })
-
-            return validateReminder(response.data)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use getLocationReminder instead.`,
-            )
-        }
+        return this.reminderClient.getReminder(id)
     }
 
     /**
@@ -1211,26 +1098,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the requested reminder.
      */
     async getLocationReminder(id: string): Promise<Reminder> {
-        ReminderIdSchema.parse(id)
-        try {
-            const response = await request<Reminder>({
-                httpMethod: 'GET',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-            })
-
-            return validateReminder(response.data)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use getReminder instead.`,
-            )
-        }
+        return this.reminderClient.getLocationReminder(id)
     }
 
     /**
@@ -1241,17 +1109,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the created reminder.
      */
     async addReminder(args: AddReminderArgs, requestId?: string): Promise<Reminder> {
-        const response = await request<Reminder>({
-            httpMethod: 'POST',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_REMINDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-            requestId: requestId,
-        })
-
-        return validateReminder(response.data)
+        return this.reminderClient.addReminder(args, requestId)
     }
 
     /**
@@ -1265,20 +1123,7 @@ export class TodoistApi {
         args: AddLocationReminderArgs,
         requestId?: string,
     ): Promise<Reminder> {
-        const response = await request<Reminder>({
-            httpMethod: 'POST',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_LOCATION_REMINDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: {
-                ...args,
-                reminderType: 'location',
-            },
-            requestId: requestId,
-        })
-
-        return validateReminder(response.data)
+        return this.reminderClient.addLocationReminder(args, requestId)
     }
 
     /**
@@ -1294,29 +1139,7 @@ export class TodoistApi {
         args: UpdateReminderArgs,
         requestId?: string,
     ): Promise<Reminder> {
-        ReminderIdSchema.parse(id)
-        const payload = UpdateReminderArgsSchema.parse(args)
-        try {
-            const response = await request<Reminder>({
-                httpMethod: 'POST',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-                payload,
-                requestId: requestId,
-            })
-
-            return validateReminder(response.data)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use updateLocationReminder instead.`,
-            )
-        }
+        return this.reminderClient.updateReminder(id, args, requestId)
     }
 
     /**
@@ -1332,29 +1155,7 @@ export class TodoistApi {
         args: UpdateLocationReminderArgs,
         requestId?: string,
     ): Promise<Reminder> {
-        ReminderIdSchema.parse(id)
-        const payload = UpdateLocationReminderArgsSchema.parse(args)
-        try {
-            const response = await request<Reminder>({
-                httpMethod: 'POST',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-                payload,
-                requestId: requestId,
-            })
-
-            return validateReminder(response.data)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use updateReminder instead.`,
-            )
-        }
+        return this.reminderClient.updateLocationReminder(id, args, requestId)
     }
 
     /**
@@ -1365,26 +1166,7 @@ export class TodoistApi {
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteReminder(id: string, requestId?: string): Promise<boolean> {
-        ReminderIdSchema.parse(id)
-        try {
-            const response = await request({
-                httpMethod: 'DELETE',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-                requestId: requestId,
-            })
-            return isSuccess(response)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Reminder ${id} was not found on the time-based reminder endpoint. If this is a location reminder, use deleteLocationReminder instead.`,
-            )
-        }
+        return this.reminderClient.deleteReminder(id, requestId)
     }
 
     /**
@@ -1395,26 +1177,7 @@ export class TodoistApi {
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteLocationReminder(id: string, requestId?: string): Promise<boolean> {
-        ReminderIdSchema.parse(id)
-        try {
-            const response = await request({
-                httpMethod: 'DELETE',
-                baseUri: this.syncApiBase,
-                relativePath: generatePath(ENDPOINT_REST_LOCATION_REMINDERS, id),
-                apiToken: this.authToken,
-                customFetch: this.customFetch,
-                requestId: requestId,
-            })
-            return isSuccess(response)
-        } catch (error) {
-            if (!(error instanceof TodoistRequestError) || error.httpStatusCode !== 404) {
-                throw error
-            }
-
-            throw new TodoistArgumentError(
-                `Location reminder ${id} was not found on the location reminder endpoint. If this is a time-based reminder, use deleteReminder instead.`,
-            )
-        }
+        return this.reminderClient.deleteLocationReminder(id, requestId)
     }
 
     /**
@@ -1680,21 +1443,7 @@ export class TodoistApi {
      * @returns A promise that resolves to a paginated response of folders.
      */
     async getFolders(args: GetFoldersArgs): Promise<GetFoldersResponse> {
-        const {
-            data: { results, nextCursor },
-        } = await request<GetFoldersResponse>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_FOLDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-        })
-
-        return {
-            results: validateFolderArray(results),
-            nextCursor,
-        }
+        return this.folderClient.getFolders(args)
     }
 
     /**
@@ -1704,16 +1453,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the requested folder.
      */
     async getFolder(id: string): Promise<Folder> {
-        z.string().parse(id)
-        const response = await request<Folder>({
-            httpMethod: 'GET',
-            baseUri: this.syncApiBase,
-            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-        })
-
-        return validateFolder(response.data)
+        return this.folderClient.getFolder(id)
     }
 
     /**
@@ -1724,17 +1464,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the created folder.
      */
     async addFolder(args: AddFolderArgs, requestId?: string): Promise<Folder> {
-        const response = await request<Folder>({
-            httpMethod: 'POST',
-            baseUri: this.syncApiBase,
-            relativePath: ENDPOINT_REST_FOLDERS,
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-            requestId: requestId,
-        })
-
-        return validateFolder(response.data)
+        return this.folderClient.addFolder(args, requestId)
     }
 
     /**
@@ -1746,18 +1476,7 @@ export class TodoistApi {
      * @returns A promise that resolves to the updated folder.
      */
     async updateFolder(id: string, args: UpdateFolderArgs, requestId?: string): Promise<Folder> {
-        z.string().parse(id)
-        const response = await request<Folder>({
-            httpMethod: 'POST',
-            baseUri: this.syncApiBase,
-            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            payload: args,
-            requestId: requestId,
-        })
-
-        return validateFolder(response.data)
+        return this.folderClient.updateFolder(id, args, requestId)
     }
 
     /**
@@ -1768,16 +1487,7 @@ export class TodoistApi {
      * @returns A promise that resolves to `true` if successful.
      */
     async deleteFolder(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
-        const response = await request({
-            httpMethod: 'DELETE',
-            baseUri: this.syncApiBase,
-            relativePath: generatePath(ENDPOINT_REST_FOLDERS, id),
-            apiToken: this.authToken,
-            customFetch: this.customFetch,
-            requestId: requestId,
-        })
-        return isSuccess(response)
+        return this.folderClient.deleteFolder(id, requestId)
     }
 
     // ── Backups ──


### PR DESCRIPTION
## Summary

Third batch in the TodoistApi domain-decomposition series (follows Doist/todoist-sdk-typescript#561, Doist/todoist-sdk-typescript#562). Migrates 21 more methods onto the sub-client pattern.

- **ReminderClient** (10 methods) — time + location variants. Preserves the `ReminderIdSchema`/`UpdateReminderArgsSchema`/`UpdateLocationReminderArgsSchema` runtime validation and the time-vs-location 404 translation that returns a `TodoistArgumentError` pointing at the sibling method.
- **InsightsClient** (6 methods) — `getProjectActivityStats`, `getProjectHealth`, `getProjectHealthContext`, `getProjectProgress`, `getWorkspaceInsights`, `analyzeProjectHealth`.
- **FolderClient** (5 methods) — `getFolders`, `getFolder`, `addFolder`, `updateFolder`, `deleteFolder`.

`TodoistApi` gains three more private fields, instantiated in the constructor from the shared `SyncRequestContext`. The 21 existing public methods collapse to one-line delegations. Public API, JSDoc, and test files are unchanged.

`src/todoist-api.ts`: **2656 → 2366 lines**.

## Test plan

- [x] `npm run ts-compile-check` passes
- [x] `npm run check` passes (oxlint + oxfmt)
- [x] `npm test` — all 479 tests pass, zero test file changes

## Remaining work

After this lands, roughly ~40 methods remain on `TodoistApi`: activity (1), productivity (1), backups (2), email-forwarding (2), id-mappings (2), templates (5), uploads (3), workspaces (~18), plus `getUser`/`sync`. Future PRs will continue the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)