### PR TITLE
fix: normalize Goal progress item→task field names

### DIFF
--- a/src/test-utils/test-defaults.ts
+++ b/src/test-utils/test-defaults.ts
@@ -11,6 +11,7 @@ import {
     WorkspaceProject,
     Reminder,
     Folder,
+    Goal,
 } from '../types'
 import type { Collaborator, CollaboratorState } from '../types/sync/resources/collaborators'
 import type { Note } from '../types/sync/resources/notes'
@@ -381,6 +382,37 @@ export const DEFAULT_COLLABORATOR_STATE: CollaboratorState = {
     projectId: DEFAULT_PROJECT_ID,
     state: 'active',
     isDeleted: false,
+}
+
+export const DEFAULT_GOAL_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+export const DEFAULT_GOAL: Goal = {
+    id: DEFAULT_GOAL_ID,
+    ownerType: 'USER',
+    ownerId: DEFAULT_USER_ID,
+    name: 'Ship v2',
+    description: 'Launch the new version',
+    deadline: '2026-04-03',
+    parentGoalId: null,
+    childOrder: 0,
+    isCompleted: false,
+    completedAt: null,
+    responsibleUid: null,
+    isDeleted: false,
+    progress: {
+        totalTaskCount: 5,
+        completedTaskCount: 2,
+        percentage: 40,
+    },
+    creatorUid: DEFAULT_USER_ID,
+    createdAt: defaultDate(),
+    updatedAt: defaultDate(),
+}
+
+export const DEFAULT_GOAL_NO_PROGRESS: Goal = {
+    ...DEFAULT_GOAL,
+    id: 'e5f6g7h8-e29b-41d4-a716-446655440001',
+    progress: undefined,
 }
 
 export const DEFAULT_NOTE: Note = {

--- a/src/todoist-api.goals.test.ts
+++ b/src/todoist-api.goals.test.ts
@@ -1,0 +1,253 @@
+import { TodoistApi } from '.'
+import {
+    getSyncBaseUri,
+    ENDPOINT_REST_GOALS,
+    ENDPOINT_REST_GOALS_SEARCH,
+    GOAL_COMPLETE,
+    GOAL_UNCOMPLETE,
+    GOAL_TASKS,
+} from './consts/endpoints'
+import { server, http, HttpResponse } from './test-utils/msw-setup'
+import {
+    DEFAULT_AUTH_TOKEN,
+    DEFAULT_GOAL,
+    DEFAULT_GOAL_ID,
+    DEFAULT_GOAL_NO_PROGRESS,
+    DEFAULT_TASK_ID,
+} from './test-utils/test-defaults'
+
+function getTarget() {
+    return new TodoistApi(DEFAULT_AUTH_TOKEN)
+}
+
+// Realistic REST payload: backend uses snake_case and "item" terminology for progress.
+// The transport layer runs camelCaseKeys() before the schema sees this, so after that
+// step the fields are `totalItemCount` / `completedItemCount` / `percentage`.
+// GoalProgressSchema.preprocess then renames them to `totalTaskCount` / `completedTaskCount`.
+const RAW_GOAL_RESPONSE = {
+    id: DEFAULT_GOAL_ID,
+    owner_type: 'USER',
+    owner_id: '5',
+    name: 'Ship v2',
+    description: 'Launch the new version',
+    deadline: '2026-04-03',
+    parent_goal_id: null,
+    child_order: 0,
+    is_completed: false,
+    completed_at: null,
+    responsible_uid: null,
+    is_deleted: false,
+    progress: {
+        total_item_count: 5,
+        completed_item_count: 2,
+        percentage: 40,
+    },
+    creator_uid: '5',
+    created_at: '2020-09-08T12:00:00Z',
+    updated_at: '2020-09-08T12:00:00Z',
+}
+
+const RAW_GOAL_RESPONSE_NO_PROGRESS = {
+    ...RAW_GOAL_RESPONSE,
+    id: DEFAULT_GOAL_NO_PROGRESS.id,
+    progress: undefined,
+}
+
+describe('TodoistApi goal endpoints', () => {
+    describe('getGoals', () => {
+        test('returns result from rest client and normalizes progress to *TaskCount', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}`, () => {
+                    return HttpResponse.json(
+                        { results: [RAW_GOAL_RESPONSE], next_cursor: 'abc' },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const { results, nextCursor } = await api.getGoals()
+
+            expect(results).toEqual([DEFAULT_GOAL])
+            expect(results[0]?.progress).toEqual({
+                totalTaskCount: 5,
+                completedTaskCount: 2,
+                percentage: 40,
+            })
+            expect(nextCursor).toBe('abc')
+        })
+
+        test('passes through goals without progress', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}`, () => {
+                    return HttpResponse.json(
+                        { results: [RAW_GOAL_RESPONSE_NO_PROGRESS], next_cursor: null },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const { results } = await api.getGoals()
+
+            expect(results[0]?.progress).toBeUndefined()
+        })
+    })
+
+    describe('searchGoals', () => {
+        test('returns result from rest client', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS_SEARCH}`, () => {
+                    return HttpResponse.json(
+                        { results: [RAW_GOAL_RESPONSE], next_cursor: null },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const { results } = await api.searchGoals({ query: 'Ship' })
+
+            expect(results).toEqual([DEFAULT_GOAL])
+        })
+    })
+
+    describe('getGoal', () => {
+        test('returns goal with normalized progress', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}`, () =>
+                    HttpResponse.json(RAW_GOAL_RESPONSE, { status: 200 }),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.getGoal(DEFAULT_GOAL_ID)
+
+            expect(goal).toEqual(DEFAULT_GOAL)
+        })
+    })
+
+    describe('addGoal', () => {
+        test('returns created goal', async () => {
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}`, () =>
+                    HttpResponse.json(RAW_GOAL_RESPONSE, { status: 200 }),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.addGoal({ name: 'Ship v2' })
+
+            expect(goal).toEqual(DEFAULT_GOAL)
+        })
+    })
+
+    describe('updateGoal', () => {
+        test('returns updated goal', async () => {
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}`, () =>
+                    HttpResponse.json(RAW_GOAL_RESPONSE, { status: 200 }),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.updateGoal(DEFAULT_GOAL_ID, { name: 'Ship v2' })
+
+            expect(goal).toEqual(DEFAULT_GOAL)
+        })
+    })
+
+    describe('deleteGoal', () => {
+        test('returns success', async () => {
+            server.use(
+                http.delete(`${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}`, () =>
+                    HttpResponse.json(undefined, { status: 204 }),
+                ),
+            )
+            const api = getTarget()
+
+            const result = await api.deleteGoal(DEFAULT_GOAL_ID)
+
+            expect(result).toBe(true)
+        })
+    })
+
+    describe('completeGoal', () => {
+        test('returns completed goal', async () => {
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}/${GOAL_COMPLETE}`,
+                    () =>
+                        HttpResponse.json(
+                            { ...RAW_GOAL_RESPONSE, is_completed: true },
+                            { status: 200 },
+                        ),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.completeGoal(DEFAULT_GOAL_ID)
+
+            expect(goal.isCompleted).toBe(true)
+            expect(goal.progress).toEqual({
+                totalTaskCount: 5,
+                completedTaskCount: 2,
+                percentage: 40,
+            })
+        })
+    })
+
+    describe('uncompleteGoal', () => {
+        test('returns reopened goal', async () => {
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}/${GOAL_UNCOMPLETE}`,
+                    () => HttpResponse.json(RAW_GOAL_RESPONSE, { status: 200 }),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.uncompleteGoal(DEFAULT_GOAL_ID)
+
+            expect(goal).toEqual(DEFAULT_GOAL)
+        })
+    })
+
+    describe('linkTaskToGoal', () => {
+        test('returns goal after linking task', async () => {
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}/${GOAL_TASKS}`,
+                    () => HttpResponse.json(RAW_GOAL_RESPONSE, { status: 200 }),
+                ),
+            )
+            const api = getTarget()
+
+            const goal = await api.linkTaskToGoal({
+                goalId: DEFAULT_GOAL_ID,
+                taskId: DEFAULT_TASK_ID,
+            })
+
+            expect(goal).toEqual(DEFAULT_GOAL)
+        })
+    })
+
+    describe('unlinkTaskFromGoal', () => {
+        test('returns success', async () => {
+            server.use(
+                http.delete(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_GOALS}/${DEFAULT_GOAL_ID}/${GOAL_TASKS}/${DEFAULT_TASK_ID}`,
+                    () => HttpResponse.json(undefined, { status: 204 }),
+                ),
+            )
+            const api = getTarget()
+
+            const result = await api.unlinkTaskFromGoal({
+                goalId: DEFAULT_GOAL_ID,
+                taskId: DEFAULT_TASK_ID,
+            })
+
+            expect(result).toBe(true)
+        })
+    })
+})

--- a/src/types/goals/types.ts
+++ b/src/types/goals/types.ts
@@ -5,11 +5,35 @@ export const GOAL_OWNER_TYPES = ['USER', 'WORKSPACE'] as const
 /** Goal owner type. */
 export type GoalOwnerType = (typeof GOAL_OWNER_TYPES)[number]
 
-export const GoalProgressSchema = z.looseObject({
-    totalTaskCount: z.number().int(),
-    completedTaskCount: z.number().int(),
-    percentage: z.number(),
-})
+/**
+ * Progress of a {@link Goal}.
+ *
+ * The REST API returns these counts under `total_item_count` / `completed_item_count`,
+ * reflecting the backend's generic "item" terminology. The SDK normalizes them to
+ * `totalTaskCount` / `completedTaskCount` so the public surface consistently speaks
+ * in "tasks" (matching the rest of the SDK). The `preprocess` step below performs
+ * that rename after the transport layer's snake_case → camelCase conversion — do not
+ * remove it without also changing the downstream field names.
+ */
+export const GoalProgressSchema = z.preprocess(
+    (raw) => {
+        if (raw === null || raw === undefined || typeof raw !== 'object') {
+            return raw
+        }
+        const { totalItemCount, completedItemCount, totalTaskCount, completedTaskCount, ...rest } =
+            raw as Record<string, unknown>
+        return {
+            ...rest,
+            totalTaskCount: totalTaskCount ?? totalItemCount,
+            completedTaskCount: completedTaskCount ?? completedItemCount,
+        }
+    },
+    z.looseObject({
+        totalTaskCount: z.number().int(),
+        completedTaskCount: z.number().int(),
+        percentage: z.number(),
+    }),
+)
 
 export type GoalProgress = z.infer<typeof GoalProgressSchema>
 

--- a/src/types/goals/types.ts
+++ b/src/types/goals/types.ts
@@ -17,7 +17,7 @@ export type GoalOwnerType = (typeof GOAL_OWNER_TYPES)[number]
  */
 export const GoalProgressSchema = z.preprocess(
     (raw) => {
-        if (raw === null || raw === undefined || typeof raw !== 'object') {
+        if (raw === null || raw === undefined || typeof raw !== 'object' || Array.isArray(raw)) {
             return raw
         }
         const { totalItemCount, completedItemCount, totalTaskCount, completedTaskCount, ...rest } =


### PR DESCRIPTION
## Summary
- `GoalProgressSchema` declared the public SDK names (`totalTaskCount` / `completedTaskCount`) but had no transform to bridge the REST API's `total_item_count` / `completed_item_count`. After the transport's `camelCaseKeys` runs, those become `totalItemCount` / `completedItemCount` — which don't match the schema — so every real goal with linked items failed zod validation and broke `getGoal` / `getGoals` / `linkTaskToGoal` etc.
- Reported by `todoist-cli@1.43.0-next.1` users (Twist thread "Goals" comment 101658680) whose agents got `expected: number, path: ["progress","totalTaskCount"]` on every goal command.
- Fix: add a `z.preprocess` step on `GoalProgressSchema` that renames `*ItemCount` → `*TaskCount` before validation, keeping the SDK's public "task" terminology.
- Also add `src/todoist-api.goals.test.ts` (there was no test file for the goals endpoints — that's why this slipped through 9.1.0-next.1) plus a `DEFAULT_GOAL` fixture.

## Test plan
- [x] `npm test` — 498/498 pass, new `todoist-api.goals.test.ts` covers list / search / get / add / update / delete / complete / uncomplete / link / unlink + no-progress case
- [x] `npx tsc --noEmit` clean
- [x] `npm run check` (oxlint + oxfmt) clean
- [ ] Downstream smoke from `todoist-cli` once a new `-next` build publishes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)