### PR TITLE
refactor: reject empty string IDs in client validators

### DIFF
--- a/src/clients/app-client.ts
+++ b/src/clients/app-client.ts
@@ -181,6 +181,7 @@ export class AppClient extends BaseClient {
         { appId, file, fileName = '', size = 'medium' }: UploadAppIconArgs,
         requestId?: string,
     ): Promise<AppWithUserCount> {
+        z.string().min(1).parse(appId)
         if (Buffer.isBuffer(file) && file.length === 0) {
             throw new Error('Cannot upload empty image file')
         }

--- a/src/clients/app-client.ts
+++ b/src/clients/app-client.ts
@@ -77,7 +77,7 @@ export class AppClient extends BaseClient {
     }
 
     async getApp(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -107,7 +107,7 @@ export class AppClient extends BaseClient {
         args: UpdateAppArgs,
         requestId?: string,
     ): Promise<AppWithUserCount> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const { appTokenScopes, ...rest } = args
         const payload: Record<string, unknown> = { ...rest }
         if (appTokenScopes !== undefined) {
@@ -126,7 +126,7 @@ export class AppClient extends BaseClient {
     }
 
     async deleteApp(appId: string, requestId?: string): Promise<boolean> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -139,7 +139,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppSecrets(appId: string, requestId?: string): Promise<AppSecrets> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppSecrets>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -152,7 +152,7 @@ export class AppClient extends BaseClient {
     }
 
     async resetAppClientSecret(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -165,7 +165,7 @@ export class AppClient extends BaseClient {
     }
 
     async revokeAppTokens(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -177,19 +177,21 @@ export class AppClient extends BaseClient {
         return validateAppWithUserCount(response.data)
     }
 
-    async uploadAppIcon(args: UploadAppIconArgs, requestId?: string): Promise<AppWithUserCount> {
-        if (Buffer.isBuffer(args.file) && args.file.length === 0) {
+    async uploadAppIcon(
+        { appId, file, fileName = '', size = 'medium' }: UploadAppIconArgs,
+        requestId?: string,
+    ): Promise<AppWithUserCount> {
+        if (Buffer.isBuffer(file) && file.length === 0) {
             throw new Error('Cannot upload empty image file')
         }
 
-        const size = args.size ?? 'medium'
         const data = await uploadMultipartFile<unknown>({
             baseUrl: this.apiRootBase,
             authToken: this.authToken,
-            endpoint: getAppIconEndpoint(args.appId, size),
-            file: args.file,
-            fileName: args.fileName,
-            additionalFields: { file_name: args.fileName ?? '' },
+            endpoint: getAppIconEndpoint(appId, size),
+            file,
+            fileName,
+            additionalFields: { file_name: fileName },
             requestId: requestId,
             customFetch: this.customFetch,
         })
@@ -197,7 +199,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppTestToken(appId: string, requestId?: string): Promise<AppTestToken> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppTestToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -210,7 +212,7 @@ export class AppClient extends BaseClient {
     }
 
     async createAppTestToken(appId: string, requestId?: string): Promise<AppTestToken> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppTestToken>({
             httpMethod: 'PUT',
             baseUri: this.apiRootBase,
@@ -226,7 +228,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppDistributionToken> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppDistributionToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -242,7 +244,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppVerificationToken> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppVerificationToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -258,7 +260,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppVerificationToken> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppVerificationToken>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -274,7 +276,7 @@ export class AppClient extends BaseClient {
         distributionToken: string,
         requestId?: string,
     ): Promise<AppByDistributionToken> {
-        z.string().parse(distributionToken)
+        z.string().min(1).parse(distributionToken)
         const response = await request<AppByDistributionToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -289,7 +291,7 @@ export class AppClient extends BaseClient {
     // --- App webhooks ---
 
     async getAppWebhook(appId: string, requestId?: string): Promise<AppWebhook | null> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<AppWebhook | null>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -319,7 +321,7 @@ export class AppClient extends BaseClient {
     }
 
     async deleteAppWebhook(appId: string, requestId?: string): Promise<boolean> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -359,7 +361,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppInstallation(installationId: string, requestId?: string): Promise<AppInstallation> {
-        z.string().parse(installationId)
+        z.string().min(1).parse(installationId)
         const response = await request<AppInstallation>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -376,7 +378,7 @@ export class AppClient extends BaseClient {
         args: UpdateAppInstallationArgs,
         requestId?: string,
     ): Promise<AppInstallation> {
-        z.string().parse(installationId)
+        z.string().min(1).parse(installationId)
         const response = await request<AppInstallation>({
             httpMethod: 'POST',
             baseUri: this.apiRootBase,
@@ -390,7 +392,7 @@ export class AppClient extends BaseClient {
     }
 
     async uninstallApp(installationId: string, requestId?: string): Promise<boolean> {
-        z.string().parse(installationId)
+        z.string().min(1).parse(installationId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,

--- a/src/clients/comment-client.ts
+++ b/src/clients/comment-client.ts
@@ -41,7 +41,7 @@ export class CommentClient extends BaseClient {
     }
 
     async getComment(id: string): Promise<Comment> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Comment>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -72,7 +72,7 @@ export class CommentClient extends BaseClient {
     }
 
     async updateComment(id: string, args: UpdateCommentArgs, requestId?: string): Promise<Comment> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Comment>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -86,7 +86,7 @@ export class CommentClient extends BaseClient {
     }
 
     async deleteComment(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/folder-client.ts
+++ b/src/clients/folder-client.ts
@@ -38,7 +38,7 @@ export class FolderClient extends BaseClient {
     }
 
     async getFolder(id: string): Promise<Folder> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Folder>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -65,7 +65,7 @@ export class FolderClient extends BaseClient {
     }
 
     async updateFolder(id: string, args: UpdateFolderArgs, requestId?: string): Promise<Folder> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Folder>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -80,7 +80,7 @@ export class FolderClient extends BaseClient {
     }
 
     async deleteFolder(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/insights-client.ts
+++ b/src/clients/insights-client.ts
@@ -39,7 +39,7 @@ export class InsightsClient extends BaseClient {
         projectId: string,
         args: GetProjectActivityStatsArgs = {},
     ): Promise<ProjectActivityStats> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const response = await request<ProjectActivityStats>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -52,7 +52,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectHealth(projectId: string): Promise<ProjectHealth> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const response = await request<ProjectHealth>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -64,7 +64,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectHealthContext(projectId: string): Promise<ProjectHealthContext> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const response = await request<ProjectHealthContext>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -76,7 +76,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectProgress(projectId: string): Promise<ProjectProgress> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const response = await request<ProjectProgress>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -91,7 +91,7 @@ export class InsightsClient extends BaseClient {
         workspaceId: string,
         args: GetWorkspaceInsightsArgs = {},
     ): Promise<WorkspaceInsights> {
-        z.string().parse(workspaceId)
+        z.string().min(1).parse(workspaceId)
         const response = await request<WorkspaceInsights>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -107,7 +107,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async analyzeProjectHealth(projectId: string, requestId?: string): Promise<ProjectHealth> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const response = await request<ProjectHealth>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,

--- a/src/clients/label-client.ts
+++ b/src/clients/label-client.ts
@@ -31,7 +31,7 @@ import { BaseClient } from './base-client'
  */
 export class LabelClient extends BaseClient {
     async getLabel(id: string): Promise<Label> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Label>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -94,7 +94,7 @@ export class LabelClient extends BaseClient {
     }
 
     async updateLabel(id: string, args: UpdateLabelArgs, requestId?: string): Promise<Label> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -108,7 +108,7 @@ export class LabelClient extends BaseClient {
     }
 
     async deleteLabel(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/project-client.ts
+++ b/src/clients/project-client.ts
@@ -60,7 +60,7 @@ import { BaseClient } from './base-client'
  */
 export class ProjectClient extends BaseClient {
     async getProject(id: string): Promise<PersonalProject | WorkspaceProject> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -150,7 +150,7 @@ export class ProjectClient extends BaseClient {
         args: UpdateProjectArgs,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -165,7 +165,7 @@ export class ProjectClient extends BaseClient {
     }
 
     async deleteProject(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,
@@ -181,7 +181,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -197,7 +197,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -274,7 +274,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         args: GetFullProjectArgs = {},
     ): Promise<GetFullProjectResponse> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const { data } = await request<Record<string, unknown>>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -294,7 +294,7 @@ export class ProjectClient extends BaseClient {
     }
 
     async joinProject(id: string, requestId?: string): Promise<JoinProjectResponse> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const { data } = await request<JoinProjectResponse>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -319,7 +319,7 @@ export class ProjectClient extends BaseClient {
         projectId: string,
         args: GetProjectCollaboratorsArgs = {},
     ): Promise<GetProjectCollaboratorsResponse> {
-        z.string().parse(projectId)
+        z.string().min(1).parse(projectId)
         const {
             data: { results, nextCursor },
         } = await request<GetProjectCollaboratorsResponse>({

--- a/src/clients/section-client.ts
+++ b/src/clients/section-client.ts
@@ -62,7 +62,7 @@ export class SectionClient extends BaseClient {
     }
 
     async getSection(id: string): Promise<Section> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Section>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -89,7 +89,7 @@ export class SectionClient extends BaseClient {
     }
 
     async updateSection(id: string, args: UpdateSectionArgs, requestId?: string): Promise<Section> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -103,7 +103,7 @@ export class SectionClient extends BaseClient {
     }
 
     async deleteSection(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,
@@ -116,7 +116,7 @@ export class SectionClient extends BaseClient {
     }
 
     async archiveSection(id: string, requestId?: string): Promise<Section> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Section>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -129,7 +129,7 @@ export class SectionClient extends BaseClient {
     }
 
     async unarchiveSection(id: string, requestId?: string): Promise<Section> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Section>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,

--- a/src/clients/task-client.ts
+++ b/src/clients/task-client.ts
@@ -47,7 +47,7 @@ const MAX_COMMAND_COUNT = 100
  */
 export class TaskClient extends BaseClient {
     async getTask(id: string): Promise<Task> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Task>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -216,7 +216,7 @@ export class TaskClient extends BaseClient {
     }
 
     async updateTask(id: string, args: UpdateTaskArgs, requestId?: string): Promise<Task> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
 
         // Translate SDK alias for due-date clearing to Todoist's accepted payload value.
         const normalizedArgs = args.dueString === null ? { ...args, dueString: 'no date' } : args
@@ -289,7 +289,7 @@ export class TaskClient extends BaseClient {
     }
 
     async moveTask(id: string, args: MoveTaskArgs, requestId?: string): Promise<Task> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Task>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -308,7 +308,7 @@ export class TaskClient extends BaseClient {
     }
 
     async closeTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -321,7 +321,7 @@ export class TaskClient extends BaseClient {
     }
 
     async reopenTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -334,7 +334,7 @@ export class TaskClient extends BaseClient {
     }
 
     async deleteTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/ui-extension-client.ts
+++ b/src/clients/ui-extension-client.ts
@@ -27,7 +27,7 @@ import { BaseClient } from './base-client'
  */
 export class UiExtensionClient extends BaseClient {
     async getUiExtension(uiExtensionId: string, requestId?: string): Promise<UiExtension> {
-        z.string().parse(uiExtensionId)
+        z.string().min(1).parse(uiExtensionId)
         const response = await request<UiExtension>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -52,7 +52,7 @@ export class UiExtensionClient extends BaseClient {
     }
 
     async getUiExtensionsForApp(appId: string, requestId?: string): Promise<UiExtension[]> {
-        z.string().parse(appId)
+        z.string().min(1).parse(appId)
         const response = await request<unknown[]>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -82,7 +82,7 @@ export class UiExtensionClient extends BaseClient {
         args: UpdateUiExtensionArgs,
         requestId?: string,
     ): Promise<UiExtension> {
-        z.string().parse(uiExtensionId)
+        z.string().min(1).parse(uiExtensionId)
         const response = await request<UiExtension>({
             httpMethod: 'PATCH',
             baseUri: this.apiRootBase,
@@ -96,7 +96,7 @@ export class UiExtensionClient extends BaseClient {
     }
 
     async deleteUiExtension(uiExtensionId: string, requestId?: string): Promise<boolean> {
-        z.string().parse(uiExtensionId)
+        z.string().min(1).parse(uiExtensionId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,

--- a/src/clients/workspace-client.ts
+++ b/src/clients/workspace-client.ts
@@ -297,7 +297,7 @@ export class WorkspaceClient extends BaseClient {
     }
 
     async getWorkspace(id: string, requestId?: string): Promise<Workspace> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Workspace>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -327,7 +327,7 @@ export class WorkspaceClient extends BaseClient {
         args: UpdateWorkspaceArgs,
         requestId?: string,
     ): Promise<Workspace> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request<Workspace>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -341,7 +341,7 @@ export class WorkspaceClient extends BaseClient {
     }
 
     async deleteWorkspace(id: string, requestId?: string): Promise<boolean> {
-        z.string().parse(id)
+        z.string().min(1).parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,


### PR DESCRIPTION
## Summary
- Follow-up to Pawel's review feedback on #560
- `z.string().parse(...)` accepts `""`, which produces malformed endpoint URLs. Switched all client ID validators to `z.string().min(1).parse(...)` so empty strings are rejected up front (58 call sites across 11 clients)
- Cleaned up `uploadAppIcon` to destructure args and set `size`/`fileName` defaults in the parameter list instead of duplicating defaults in the body

## Test plan
- [x] `npx vitest run` — 519/519 passing
- [x] `npx oxlint src` — clean
- [x] `npx oxfmt --check src/clients` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)