### PR TITLE
feat: include clientId in app list and detail responses

### DIFF
--- a/src/test-utils/test-defaults.ts
+++ b/src/test-utils/test-defaults.ts
@@ -401,6 +401,7 @@ export const DEFAULT_ACCESS_TOKEN_ID = '3003'
 
 export const DEFAULT_APP: App = {
     id: DEFAULT_APP_ID,
+    clientId: 'client-id-xyz',
     status: 'public',
     displayName: 'Sample App',
     userId: DEFAULT_USER_ID,

--- a/src/types/apps/types.ts
+++ b/src/types/apps/types.ts
@@ -174,6 +174,7 @@ export const AppTokenScopesSchema = z
  */
 export const AppSchema = z.object({
     id: StringOrNumberSchema,
+    clientId: z.string(),
     status: AppStatusSchema,
     displayName: z.string(),
     userId: StringOrNumberSchema,


### PR DESCRIPTION
## Summary

- Adds `clientId: string` to `AppSchema` (and by inheritance `AppWithUserCountSchema`) so responses from `GET /apps` and `GET /apps/<app_id>` parse correctly once [Doist/Todoist#27400](https://github.com/Doist/Todoist/pull/27400) ships.
- Consumers can now read `clientId` directly off `App` / `AppWithUserCount` without a separate call to `/apps/<app_id>/secrets` (which also exposes `clientSecret`).
- Updates `DEFAULT_APP` fixture so existing app-endpoint tests round-trip the new field.

## Test plan

- [x] `npx vitest run src/todoist-api.apps.test.ts` — 21/21 pass
- [x] `npx oxlint src/... && npx oxfmt --check src/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)