### PR TITLE
feat: reject tmp- placeholder IDs in client validators

### DIFF
--- a/src/clients/app-client.ts
+++ b/src/clients/app-client.ts
@@ -40,6 +40,7 @@ import { webhookEventToWireName } from '../types/apps'
 import { camelCaseKeys } from '../utils/case-conversion'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import {
+    IdSchema,
     validateApp,
     validateAppArray,
     validateAppByDistributionToken,
@@ -77,7 +78,7 @@ export class AppClient extends BaseClient {
     }
 
     async getApp(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -107,7 +108,7 @@ export class AppClient extends BaseClient {
         args: UpdateAppArgs,
         requestId?: string,
     ): Promise<AppWithUserCount> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const { appTokenScopes, ...rest } = args
         const payload: Record<string, unknown> = { ...rest }
         if (appTokenScopes !== undefined) {
@@ -126,7 +127,7 @@ export class AppClient extends BaseClient {
     }
 
     async deleteApp(appId: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -139,7 +140,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppSecrets(appId: string, requestId?: string): Promise<AppSecrets> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppSecrets>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -152,7 +153,7 @@ export class AppClient extends BaseClient {
     }
 
     async resetAppClientSecret(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -165,7 +166,7 @@ export class AppClient extends BaseClient {
     }
 
     async revokeAppTokens(appId: string, requestId?: string): Promise<AppWithUserCount> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppWithUserCount>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -181,7 +182,7 @@ export class AppClient extends BaseClient {
         { appId, file, fileName = '', size = 'medium' }: UploadAppIconArgs,
         requestId?: string,
     ): Promise<AppWithUserCount> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         if (Buffer.isBuffer(file) && file.length === 0) {
             throw new Error('Cannot upload empty image file')
         }
@@ -200,7 +201,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppTestToken(appId: string, requestId?: string): Promise<AppTestToken> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppTestToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -213,7 +214,7 @@ export class AppClient extends BaseClient {
     }
 
     async createAppTestToken(appId: string, requestId?: string): Promise<AppTestToken> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppTestToken>({
             httpMethod: 'PUT',
             baseUri: this.apiRootBase,
@@ -229,7 +230,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppDistributionToken> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppDistributionToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -245,7 +246,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppVerificationToken> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppVerificationToken>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -261,7 +262,7 @@ export class AppClient extends BaseClient {
         appId: string,
         requestId?: string,
     ): Promise<AppVerificationToken> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppVerificationToken>({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -292,7 +293,7 @@ export class AppClient extends BaseClient {
     // --- App webhooks ---
 
     async getAppWebhook(appId: string, requestId?: string): Promise<AppWebhook | null> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<AppWebhook | null>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -322,7 +323,7 @@ export class AppClient extends BaseClient {
     }
 
     async deleteAppWebhook(appId: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,
@@ -362,7 +363,7 @@ export class AppClient extends BaseClient {
     }
 
     async getAppInstallation(installationId: string, requestId?: string): Promise<AppInstallation> {
-        z.string().min(1).parse(installationId)
+        IdSchema.parse(installationId)
         const response = await request<AppInstallation>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -379,7 +380,7 @@ export class AppClient extends BaseClient {
         args: UpdateAppInstallationArgs,
         requestId?: string,
     ): Promise<AppInstallation> {
-        z.string().min(1).parse(installationId)
+        IdSchema.parse(installationId)
         const response = await request<AppInstallation>({
             httpMethod: 'POST',
             baseUri: this.apiRootBase,
@@ -393,7 +394,7 @@ export class AppClient extends BaseClient {
     }
 
     async uninstallApp(installationId: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(installationId)
+        IdSchema.parse(installationId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,

--- a/src/clients/comment-client.ts
+++ b/src/clients/comment-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import { ENDPOINT_REST_COMMENTS } from '../consts/endpoints'
 import { isSuccess, request } from '../transport/http-client'
 import type {
@@ -10,7 +9,7 @@ import type {
     UpdateCommentArgs,
 } from '../types/comments'
 import { generatePath } from '../utils/request-helpers'
-import { validateComment, validateCommentArray } from '../utils/validators'
+import { IdSchema, validateComment, validateCommentArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
@@ -41,7 +40,7 @@ export class CommentClient extends BaseClient {
     }
 
     async getComment(id: string): Promise<Comment> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Comment>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -72,7 +71,7 @@ export class CommentClient extends BaseClient {
     }
 
     async updateComment(id: string, args: UpdateCommentArgs, requestId?: string): Promise<Comment> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Comment>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -86,7 +85,7 @@ export class CommentClient extends BaseClient {
     }
 
     async deleteComment(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/folder-client.ts
+++ b/src/clients/folder-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import { ENDPOINT_REST_FOLDERS } from '../consts/endpoints'
 import { isSuccess, request } from '../transport/http-client'
 import type {
@@ -9,7 +8,7 @@ import type {
 } from '../types/folders'
 import type { Folder } from '../types/sync/resources/folders'
 import { generatePath } from '../utils/request-helpers'
-import { validateFolder, validateFolderArray } from '../utils/validators'
+import { IdSchema, validateFolder, validateFolderArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
@@ -38,7 +37,7 @@ export class FolderClient extends BaseClient {
     }
 
     async getFolder(id: string): Promise<Folder> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Folder>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -65,7 +64,7 @@ export class FolderClient extends BaseClient {
     }
 
     async updateFolder(id: string, args: UpdateFolderArgs, requestId?: string): Promise<Folder> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Folder>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -80,7 +79,7 @@ export class FolderClient extends BaseClient {
     }
 
     async deleteFolder(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/insights-client.ts
+++ b/src/clients/insights-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     getProjectInsightsActivityStatsEndpoint,
     getProjectInsightsHealthAnalyzeEndpoint,
@@ -18,6 +17,7 @@ import type {
     WorkspaceInsights,
 } from '../types/insights'
 import {
+    IdSchema,
     validateProjectActivityStats,
     validateProjectHealth,
     validateProjectHealthContext,
@@ -39,7 +39,7 @@ export class InsightsClient extends BaseClient {
         projectId: string,
         args: GetProjectActivityStatsArgs = {},
     ): Promise<ProjectActivityStats> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const response = await request<ProjectActivityStats>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -52,7 +52,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectHealth(projectId: string): Promise<ProjectHealth> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const response = await request<ProjectHealth>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -64,7 +64,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectHealthContext(projectId: string): Promise<ProjectHealthContext> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const response = await request<ProjectHealthContext>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -76,7 +76,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async getProjectProgress(projectId: string): Promise<ProjectProgress> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const response = await request<ProjectProgress>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -91,7 +91,7 @@ export class InsightsClient extends BaseClient {
         workspaceId: string,
         args: GetWorkspaceInsightsArgs = {},
     ): Promise<WorkspaceInsights> {
-        z.string().min(1).parse(workspaceId)
+        IdSchema.parse(workspaceId)
         const response = await request<WorkspaceInsights>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -107,7 +107,7 @@ export class InsightsClient extends BaseClient {
     }
 
     async analyzeProjectHealth(projectId: string, requestId?: string): Promise<ProjectHealth> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const response = await request<ProjectHealth>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,

--- a/src/clients/label-client.ts
+++ b/src/clients/label-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     ENDPOINT_REST_LABELS,
     ENDPOINT_REST_LABELS_SEARCH,
@@ -20,7 +19,7 @@ import type {
     UpdateLabelArgs,
 } from '../types/labels'
 import { generatePath } from '../utils/request-helpers'
-import { validateLabel, validateLabelArray } from '../utils/validators'
+import { IdSchema, validateLabel, validateLabelArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
@@ -31,7 +30,7 @@ import { BaseClient } from './base-client'
  */
 export class LabelClient extends BaseClient {
     async getLabel(id: string): Promise<Label> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Label>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -94,7 +93,7 @@ export class LabelClient extends BaseClient {
     }
 
     async updateLabel(id: string, args: UpdateLabelArgs, requestId?: string): Promise<Label> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -108,7 +107,7 @@ export class LabelClient extends BaseClient {
     }
 
     async deleteLabel(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/project-client.ts
+++ b/src/clients/project-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     ENDPOINT_REST_PROJECTS,
     ENDPOINT_REST_PROJECTS_ARCHIVED,
@@ -37,6 +36,7 @@ import type {
 } from '../types/projects'
 import { generatePath } from '../utils/request-helpers'
 import {
+    IdSchema,
     validateCollaboratorArray,
     validateCollaboratorStateArray,
     validateCommentArray,
@@ -60,7 +60,7 @@ import { BaseClient } from './base-client'
  */
 export class ProjectClient extends BaseClient {
     async getProject(id: string): Promise<PersonalProject | WorkspaceProject> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -150,7 +150,7 @@ export class ProjectClient extends BaseClient {
         args: UpdateProjectArgs,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -165,7 +165,7 @@ export class ProjectClient extends BaseClient {
     }
 
     async deleteProject(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,
@@ -181,7 +181,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -197,7 +197,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         requestId?: string,
     ): Promise<PersonalProject | WorkspaceProject> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<PersonalProject | WorkspaceProject>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -274,7 +274,7 @@ export class ProjectClient extends BaseClient {
         id: string,
         args: GetFullProjectArgs = {},
     ): Promise<GetFullProjectResponse> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const { data } = await request<Record<string, unknown>>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -294,7 +294,7 @@ export class ProjectClient extends BaseClient {
     }
 
     async joinProject(id: string, requestId?: string): Promise<JoinProjectResponse> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const { data } = await request<JoinProjectResponse>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -319,7 +319,7 @@ export class ProjectClient extends BaseClient {
         projectId: string,
         args: GetProjectCollaboratorsArgs = {},
     ): Promise<GetProjectCollaboratorsResponse> {
-        z.string().min(1).parse(projectId)
+        IdSchema.parse(projectId)
         const {
             data: { results, nextCursor },
         } = await request<GetProjectCollaboratorsResponse>({

--- a/src/clients/section-client.ts
+++ b/src/clients/section-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     ENDPOINT_REST_SECTIONS,
     ENDPOINT_REST_SECTIONS_SEARCH,
@@ -15,7 +14,7 @@ import type {
     UpdateSectionArgs,
 } from '../types/sections'
 import { generatePath } from '../utils/request-helpers'
-import { validateSection, validateSectionArray } from '../utils/validators'
+import { IdSchema, validateSection, validateSectionArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
@@ -62,7 +61,7 @@ export class SectionClient extends BaseClient {
     }
 
     async getSection(id: string): Promise<Section> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Section>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -89,7 +88,7 @@ export class SectionClient extends BaseClient {
     }
 
     async updateSection(id: string, args: UpdateSectionArgs, requestId?: string): Promise<Section> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -103,7 +102,7 @@ export class SectionClient extends BaseClient {
     }
 
     async deleteSection(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,
@@ -116,7 +115,7 @@ export class SectionClient extends BaseClient {
     }
 
     async archiveSection(id: string, requestId?: string): Promise<Section> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Section>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -129,7 +128,7 @@ export class SectionClient extends BaseClient {
     }
 
     async unarchiveSection(id: string, requestId?: string): Promise<Section> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Section>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,

--- a/src/clients/task-client.ts
+++ b/src/clients/task-client.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from 'uuid'
-import { z } from 'zod'
 import {
     ENDPOINT_REST_TASKS,
     ENDPOINT_REST_TASKS_COMPLETED,
@@ -34,7 +33,7 @@ import type {
 } from '../types/tasks'
 import { generatePath, spreadIfDefined } from '../utils/request-helpers'
 import { processTaskContent } from '../utils/uncompletable-helpers'
-import { validateTask, validateTaskArray } from '../utils/validators'
+import { IdSchema, validateTask, validateTaskArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 const MAX_COMMAND_COUNT = 100
@@ -47,7 +46,7 @@ const MAX_COMMAND_COUNT = 100
  */
 export class TaskClient extends BaseClient {
     async getTask(id: string): Promise<Task> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Task>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -216,7 +215,7 @@ export class TaskClient extends BaseClient {
     }
 
     async updateTask(id: string, args: UpdateTaskArgs, requestId?: string): Promise<Task> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
 
         // Translate SDK alias for due-date clearing to Todoist's accepted payload value.
         const normalizedArgs = args.dueString === null ? { ...args, dueString: 'no date' } : args
@@ -289,7 +288,7 @@ export class TaskClient extends BaseClient {
     }
 
     async moveTask(id: string, args: MoveTaskArgs, requestId?: string): Promise<Task> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Task>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -308,7 +307,7 @@ export class TaskClient extends BaseClient {
     }
 
     async closeTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -321,7 +320,7 @@ export class TaskClient extends BaseClient {
     }
 
     async reopenTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -334,7 +333,7 @@ export class TaskClient extends BaseClient {
     }
 
     async deleteTask(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/clients/ui-extension-client.ts
+++ b/src/clients/ui-extension-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     ENDPOINT_REST_APPS_UI_EXTENSIONS,
     ENDPOINT_REST_APPS_UI_EXTENSIONS_INSTALLED,
@@ -15,7 +14,7 @@ import type {
 } from '../types/ui-extensions'
 import { camelCaseKeys } from '../utils/case-conversion'
 import { uploadMultipartFile } from '../utils/multipart-upload'
-import { validateUiExtension, validateUiExtensionArray } from '../utils/validators'
+import { IdSchema, validateUiExtension, validateUiExtensionArray } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
@@ -27,7 +26,7 @@ import { BaseClient } from './base-client'
  */
 export class UiExtensionClient extends BaseClient {
     async getUiExtension(uiExtensionId: string, requestId?: string): Promise<UiExtension> {
-        z.string().min(1).parse(uiExtensionId)
+        IdSchema.parse(uiExtensionId)
         const response = await request<UiExtension>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -52,7 +51,7 @@ export class UiExtensionClient extends BaseClient {
     }
 
     async getUiExtensionsForApp(appId: string, requestId?: string): Promise<UiExtension[]> {
-        z.string().min(1).parse(appId)
+        IdSchema.parse(appId)
         const response = await request<unknown[]>({
             httpMethod: 'GET',
             baseUri: this.apiRootBase,
@@ -82,7 +81,7 @@ export class UiExtensionClient extends BaseClient {
         args: UpdateUiExtensionArgs,
         requestId?: string,
     ): Promise<UiExtension> {
-        z.string().min(1).parse(uiExtensionId)
+        IdSchema.parse(uiExtensionId)
         const response = await request<UiExtension>({
             httpMethod: 'PATCH',
             baseUri: this.apiRootBase,
@@ -96,7 +95,7 @@ export class UiExtensionClient extends BaseClient {
     }
 
     async deleteUiExtension(uiExtensionId: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(uiExtensionId)
+        IdSchema.parse(uiExtensionId)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.apiRootBase,

--- a/src/clients/workspace-client.ts
+++ b/src/clients/workspace-client.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
     ENDPOINT_REST_WORKSPACES,
     ENDPOINT_WORKSPACE_INVITATIONS,
@@ -49,6 +48,7 @@ import type {
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { generatePath } from '../utils/request-helpers'
 import {
+    IdSchema,
     validateJoinWorkspaceResult,
     validateMemberActivityInfoArray,
     validateProject,
@@ -297,7 +297,7 @@ export class WorkspaceClient extends BaseClient {
     }
 
     async getWorkspace(id: string, requestId?: string): Promise<Workspace> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Workspace>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
@@ -327,7 +327,7 @@ export class WorkspaceClient extends BaseClient {
         args: UpdateWorkspaceArgs,
         requestId?: string,
     ): Promise<Workspace> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request<Workspace>({
             httpMethod: 'POST',
             baseUri: this.syncApiBase,
@@ -341,7 +341,7 @@ export class WorkspaceClient extends BaseClient {
     }
 
     async deleteWorkspace(id: string, requestId?: string): Promise<boolean> {
-        z.string().min(1).parse(id)
+        IdSchema.parse(id)
         const response = await request({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -16,6 +16,7 @@ import {
     DEFAULT_WORKSPACE_PROJECT,
 } from '../test-utils/test-defaults'
 import {
+    IdSchema,
     validateTask,
     validateTaskArray,
     validateProject,
@@ -247,6 +248,25 @@ describe('validators', () => {
             expect(() => {
                 validateUserArray([INVALID_USER])
             }).toThrow(ZodError)
+        })
+    })
+
+    describe('IdSchema', () => {
+        test('passes for a plain non-empty ID', () => {
+            const result = IdSchema.parse('6X4Vw2Hq9J3mC8kF')
+            expect(result).toBe('6X4Vw2Hq9J3mC8kF')
+        })
+
+        test('throws ZodError for an empty string', () => {
+            expect(() => IdSchema.parse('')).toThrow(ZodError)
+        })
+
+        test('throws ZodError for a tmp- prefixed ID', () => {
+            expect(() => IdSchema.parse('tmp-abc-123')).toThrow(ZodError)
+        })
+
+        test('tmp- rejection surfaces the client-side placeholder guidance', () => {
+            expect(() => IdSchema.parse('tmp-abc-123')).toThrow(/client-side placeholder/)
         })
     })
 })

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -72,6 +72,14 @@ function createValidator<T>(schema: ZodType<T>) {
     }
 }
 
+const TMP_ID_MESSAGE =
+    'This looks like a client-side placeholder — wait for sync to complete before calling the API.'
+
+export const IdSchema = z
+    .string()
+    .min(1)
+    .refine((id) => !id.startsWith('tmp-'), { message: TMP_ID_MESSAGE })
+
 // Entity validators
 
 export const { validate: validateTask, validateArray: validateTaskArray } =


### PR DESCRIPTION
## Summary
- Closes #583 — follow-up to #582
- `tmp-`-prefixed IDs are client-side optimistic-update placeholders that are never valid against REST endpoints; calling the SDK with one previously surfaced a confusing `Non-base32 digit found` error from the server
- Extracted a shared `IdSchema` in `src/utils/validators.ts` that rejects empty strings *and* `tmp-` placeholders with the guidance *"This looks like a client-side placeholder — wait for sync to complete before calling the API."*
- Swapped it in at all 58 ID call sites across 10 clients. The one non-ID call site (`distributionToken` in `app-client.ts`) keeps the plain non-empty check
- Context: [Doist/Issues#19725 (comment)](https://github.com/Doist/Issues/issues/19725#issuecomment-4268203604)

## Test plan
- [x] `npx vitest run` — 523/523 passing (includes 4 new `IdSchema` tests)
- [x] `npx oxlint src` — clean
- [x] `npx oxfmt --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)