### PR TITLE
feat: add folderId and workspaceId filters to projects endpoints

### DIFF
--- a/src/todoist-api.projects.test.ts
+++ b/src/todoist-api.projects.test.ts
@@ -69,6 +69,23 @@ describe('TodoistApi project endpoints', () => {
             expect(results).toEqual(projects)
             expect(nextCursor).toBe('123')
         })
+
+        test('forwards folderId and workspaceId as snake_case query params', async () => {
+            let capturedUrl = ''
+            server.use(
+                http.get(`${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}`, ({ request }) => {
+                    capturedUrl = request.url
+                    return HttpResponse.json({ results: [], nextCursor: null }, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.getProjects({ folderId: '5', workspaceId: '9' })
+
+            const params = new URL(capturedUrl).searchParams
+            expect(params.get('folder_id')).toBe('5')
+            expect(params.get('workspace_id')).toBe('9')
+        })
     })
 
     describe('searchProjects', () => {
@@ -133,6 +150,26 @@ describe('TodoistApi project endpoints', () => {
             const result = await api.updateProject('123', DEFAULT_UPDATE_PROJECT_ARGS)
 
             expect(result).toEqual(returnedProject)
+        })
+
+        test('sends folderId as snake_case in body, preserving null for clear', async () => {
+            const capturedBodies: unknown[] = []
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}/123`,
+                    async ({ request }) => {
+                        capturedBodies.push(await request.json())
+                        return HttpResponse.json(DEFAULT_WORKSPACE_PROJECT, { status: 200 })
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            await api.updateProject('123', { folderId: '42' })
+            await api.updateProject('123', { folderId: null })
+
+            expect(capturedBodies[0]).toEqual({ folder_id: '42' })
+            expect(capturedBodies[1]).toEqual({ folder_id: null })
         })
     })
 

--- a/src/types/projects/requests.ts
+++ b/src/types/projects/requests.ts
@@ -20,6 +20,10 @@ import type {
  * @see https://developer.todoist.com/api/v1/#tag/Projects/operation/get_projects_api_v1_projects_get
  */
 export type GetProjectsArgs = {
+    /** Filter projects to only those in this folder. If provided, workspaceId is ignored. */
+    folderId?: string | null
+    /** Filter projects to only those in this workspace. Ignored if folderId is also provided. */
+    workspaceId?: string | null
     cursor?: string | null
     limit?: number
 }
@@ -78,6 +82,11 @@ export type UpdateProjectArgs = {
     color?: ColorKey
     isFavorite?: boolean
     viewStyle?: ProjectViewStyle
+    /**
+     * Folder to move the project into. Only supported for workspace projects.
+     * Pass `null` to clear the value. Omit this field to keep it unchanged.
+     */
+    folderId?: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary

Mirrors upstream REST API changes from [Doist/Todoist#27377](https://github.com/Doist/Todoist/pull/27377) in the SDK:

- `getProjects()` — new optional `folderId` and `workspaceId` filters. If `folderId` is provided, `workspaceId` is ignored (matches server behaviour).
- `updateProject()` — new optional `folderId` to move a workspace project into / out of a folder. Omit to leave unchanged, pass `null` to clear, pass an ID to set. Server rejects this on personal projects.

All IDs typed as `string | null` to stay consistent with the rest of the SDK (`WorkspaceProject.folderId`, `MoveProjectToWorkspaceArgs.folderId`, etc.). No client-layer changes needed — args flow through the existing `snakeCaseKeys` pipeline.

## Test plan

- [x] `npx vitest run src/todoist-api.projects.test.ts` — 19/19 pass, including two new tests asserting the snake_case wire format (`folder_id`/`workspace_id` query params on `getProjects`, `folder_id: null` preserved in `updateProject` body)
- [x] `npx oxlint src` — 0 warnings, 0 errors
- [x] `npx oxfmt --check` — clean
- [x] `npx tsc --noEmit` — no new errors in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)