### PR TITLE
feat!: type ProductivityStats goal flags and ignoreDays

### DIFF
--- a/src/todoist-api.user.test.ts
+++ b/src/todoist-api.user.test.ts
@@ -1,4 +1,4 @@
-import { TodoistApi, type CurrentUser, type ProductivityStats } from '.'
+import { TodoistApi, type CurrentUser } from '.'
 import { getSyncBaseUri, ENDPOINT_REST_USER, ENDPOINT_REST_PRODUCTIVITY } from './consts/endpoints'
 import { server, http, HttpResponse } from './test-utils/msw-setup'
 import { DEFAULT_AUTH_TOKEN } from './test-utils/test-defaults'
@@ -42,7 +42,7 @@ const DEFAULT_CURRENT_USER_RESPONSE: CurrentUser = {
     weekendStartDay: 6,
 }
 
-const PRODUCTIVITY_STATS_RESPONSE: ProductivityStats = {
+const PRODUCTIVITY_STATS_RESPONSE = {
     completedCount: 42,
     daysItems: [
         {
@@ -195,7 +195,16 @@ describe('TodoistApi user endpoints', () => {
             )
             const api = getTarget()
             const stats = await api.getProductivityStats()
-            expect(stats).toEqual(PRODUCTIVITY_STATS_RESPONSE)
+            expect(stats).toEqual({
+                ...PRODUCTIVITY_STATS_RESPONSE,
+                goals: {
+                    ...PRODUCTIVITY_STATS_RESPONSE.goals,
+                    karmaDisabled: false,
+                    vacationMode: true,
+                },
+            })
+            expect(stats.goals.karmaDisabled).toBe(false)
+            expect(stats.goals.vacationMode).toBe(true)
         })
     })
 })

--- a/src/todoist-api.user.test.ts
+++ b/src/todoist-api.user.test.ts
@@ -199,12 +199,14 @@ describe('TodoistApi user endpoints', () => {
                 ...PRODUCTIVITY_STATS_RESPONSE,
                 goals: {
                     ...PRODUCTIVITY_STATS_RESPONSE.goals,
+                    ignoreDays: ['Friday', 'Saturday'],
                     karmaDisabled: false,
                     vacationMode: true,
                 },
             })
             expect(stats.goals.karmaDisabled).toBe(false)
             expect(stats.goals.vacationMode).toBe(true)
+            expect(stats.goals.ignoreDays).toEqual(['Friday', 'Saturday'])
         })
     })
 })

--- a/src/transport/sync-request.ts
+++ b/src/transport/sync-request.ts
@@ -66,6 +66,9 @@ function serializeUpdateGoalsArgs(args: UpdateGoalsArgs): Record<string, unknown
         ...spreadIfDefined(args.karmaDisabled, (v) => ({
             karmaDisabled: v ? 1 : 0,
         })),
+        ...spreadIfDefined(args.ignoreDays, (v) => ({
+            ignoreDays: v.map((day) => DAY_OF_WEEK_TO_API[day]),
+        })),
     }
 }
 

--- a/src/transport/sync-request.ts
+++ b/src/transport/sync-request.ts
@@ -1,5 +1,5 @@
 import { ENDPOINT_SYNC } from '../consts/endpoints'
-import { TodoistRequestError } from '../types'
+import { TodoistArgumentError, TodoistRequestError } from '../types'
 import type { CustomFetch } from '../types/http'
 import {
     type SyncCommand,
@@ -67,7 +67,15 @@ function serializeUpdateGoalsArgs(args: UpdateGoalsArgs): Record<string, unknown
             karmaDisabled: v ? 1 : 0,
         })),
         ...spreadIfDefined(args.ignoreDays, (v) => ({
-            ignoreDays: v.map((day) => DAY_OF_WEEK_TO_API[day]),
+            ignoreDays: v.map((day) => {
+                const apiValue = DAY_OF_WEEK_TO_API[day]
+                if (apiValue === undefined) {
+                    throw new TodoistArgumentError(
+                        `Invalid ignoreDays entry "${String(day)}". Expected a DayOfWeek (e.g. "Monday").`,
+                    )
+                }
+                return apiValue
+            }),
         })),
     }
 }

--- a/src/types/productivity/types.ts
+++ b/src/types/productivity/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { BooleanFromZeroOneSchema } from '../sync/user-preferences'
 
 export const StreakSchema = z.object({
     count: z.number(),
@@ -37,14 +38,14 @@ export const ProductivityStatsSchema = z.object({
         currentWeeklyStreak: StreakSchema,
         dailyGoal: z.number(),
         ignoreDays: z.array(z.number()),
-        karmaDisabled: z.number(),
+        karmaDisabled: BooleanFromZeroOneSchema,
         lastDailyStreak: StreakSchema,
         lastWeeklyStreak: StreakSchema,
         maxDailyStreak: StreakSchema,
         maxWeeklyStreak: StreakSchema,
         user: z.string(),
         userId: z.string(),
-        vacationMode: z.number(),
+        vacationMode: BooleanFromZeroOneSchema,
         weeklyGoal: z.number(),
     }),
     karma: z.number(),

--- a/src/types/productivity/types.ts
+++ b/src/types/productivity/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { BooleanFromZeroOneSchema } from '../sync/user-preferences'
+import { BooleanFromZeroOneSchema, DayOfWeekSchema } from '../sync/user-preferences'
 
 export const StreakSchema = z.object({
     count: z.number(),
@@ -37,7 +37,7 @@ export const ProductivityStatsSchema = z.object({
         currentDailyStreak: StreakSchema,
         currentWeeklyStreak: StreakSchema,
         dailyGoal: z.number(),
-        ignoreDays: z.array(z.number()),
+        ignoreDays: z.array(DayOfWeekSchema),
         karmaDisabled: BooleanFromZeroOneSchema,
         lastDailyStreak: StreakSchema,
         lastWeeklyStreak: StreakSchema,

--- a/src/types/sync/commands/others.ts
+++ b/src/types/sync/commands/others.ts
@@ -39,7 +39,7 @@ export type UserSettingsUpdateArgs = {
 export type UpdateGoalsArgs = {
     dailyGoal?: number
     weeklyGoal?: number
-    ignoreDays?: number[]
+    ignoreDays?: DayOfWeek[]
     vacationMode?: boolean
     karmaDisabled?: boolean
 }


### PR DESCRIPTION
## Summary

- `goals.karmaDisabled` and `goals.vacationMode` in `ProductivityStatsSchema` are now parsed as `boolean` (the API returns `0`/`1`, but they're semantically flags). Reuses the existing `BooleanFromZeroOneSchema`.
- `goals.ignoreDays` is now surfaced as `DayOfWeek[]` (`'Monday' | … | 'Sunday'`) instead of `number[]`. Outbound `update_goals` payloads map back to integers via the existing `DAY_OF_WEEK_TO_API` mapping in `serializeUpdateGoalsArgs`.
- Test fixture updated: HTTP mock keeps the raw wire shape (`0`/`1`, `[5, 6]`); assertion expects the parsed booleans and day names, exercising the transforms.

## Breaking changes

- `ProductivityStats['goals']['karmaDisabled']`: `number` → `boolean`
- `ProductivityStats['goals']['vacationMode']`: `number` → `boolean`
- `ProductivityStats['goals']['ignoreDays']`: `number[]` → `DayOfWeek[]`
- `UpdateGoalsArgs['ignoreDays']`: `number[]` → `DayOfWeek[]`

The `vacationMode` / `karmaDisabled` fields on `UpdateGoalsArgs` were already `boolean` and remain unchanged on the write side.

## Test plan

- [x] `npx vitest run` — full suite (571/571) passes
- [x] `npx oxlint` + `npx oxfmt --check` clean on touched files
- [x] `getProductivityStats` test asserts `karmaDisabled === false`, `vacationMode === true`, `ignoreDays === ['Friday', 'Saturday']`
- [ ] Manual sanity: call `getProductivityStats()` against a real account and confirm the parsed shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)