### PR TITLE
fix: decompress gzipped responses on Node 24+ (undici 7)

### DIFF
--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -1,3 +1,8 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { gzipSync } from 'node:zlib'
+import { http, passthrough } from 'msw'
+import { server } from '../test-utils/msw-setup'
 import { getDefaultDispatcher, resetDefaultDispatcherForTests } from './http-dispatcher'
 
 describe('http-dispatcher', () => {
@@ -29,5 +34,61 @@ describe('http-dispatcher', () => {
 
         expect(secondDispatcher).toBeDefined()
         expect(secondDispatcher).not.toBe(firstDispatcher)
+    })
+
+    test('decompresses gzip-encoded response bodies', async () => {
+        const payload = { hello: 'world', nested: { value: 42 } }
+        const compressed = gzipSync(Buffer.from(JSON.stringify(payload)))
+
+        const httpServer: Server = await new Promise((resolve) => {
+            const s = createServer((_req, res) => {
+                res.writeHead(200, {
+                    'content-type': 'application/json',
+                    'content-encoding': 'gzip',
+                    'content-length': String(compressed.length),
+                })
+                res.end(compressed)
+            })
+            s.listen(0, '127.0.0.1', () => resolve(s))
+        })
+
+        const { port } = httpServer.address() as AddressInfo
+        const url = `http://127.0.0.1:${port}/`
+        // Bypass msw for this localhost endpoint so the real bytes (with the
+        // real `content-encoding` header) reach the dispatcher under test.
+        server.use(http.get(url, () => passthrough()))
+
+        try {
+            const dispatcher = await getDefaultDispatcher()
+            const response = await fetch(url, {
+                // @ts-expect-error - dispatcher is a valid Node fetch option not in TS lib types
+                dispatcher,
+            })
+            const body = await response.text()
+
+            expect(response.status).toBe(200)
+            expect(body).toBe(JSON.stringify(payload))
+            expect(JSON.parse(body)).toEqual(payload)
+        } finally {
+            await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+        }
+    })
+
+    test('does not emit ExperimentalWarning for decompress interceptor', async () => {
+        const warnings: Array<{ name: string; message: string }> = []
+        function listener(warning: Error): void {
+            warnings.push({ name: warning.name, message: warning.message })
+        }
+        process.on('warning', listener)
+        try {
+            await getDefaultDispatcher()
+        } finally {
+            process.off('warning', listener)
+        }
+
+        const decompressWarnings = warnings.filter(
+            (w) => w.name === 'ExperimentalWarning' && w.message.includes('DecompressInterceptor'),
+        )
+        expect(decompressWarnings).toEqual([])
     })
 })

--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -3,19 +3,22 @@ import type { AddressInfo } from 'node:net'
 import { gzipSync } from 'node:zlib'
 import { http, passthrough } from 'msw'
 import { server } from '../test-utils/msw-setup'
-import { getDefaultDispatcher, resetDefaultDispatcherForTests } from './http-dispatcher'
+import {
+    getDefaultDispatcher,
+    resetDefaultDispatcherForTests,
+    suppressExperimentalWarningsSync,
+} from './http-dispatcher'
 
 describe('http-dispatcher', () => {
     afterEach(async () => {
         await resetDefaultDispatcherForTests()
     })
 
-    test('returns an EnvHttpProxyAgent in Node', async () => {
+    test('returns a dispatcher in Node', async () => {
         const dispatcher = await getDefaultDispatcher()
-        const { EnvHttpProxyAgent } = await import('undici')
 
         expect(dispatcher).toBeDefined()
-        expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+        expect(typeof dispatcher?.dispatch).toBe('function')
     })
 
     test('caches the dispatcher instance', async () => {
@@ -73,22 +76,51 @@ describe('http-dispatcher', () => {
             await new Promise<void>((resolve) => httpServer.close(() => resolve()))
         }
     })
+})
 
-    test('does not emit ExperimentalWarning for decompress interceptor', async () => {
-        const warnings: Array<{ name: string; message: string }> = []
-        function listener(warning: Error): void {
-            warnings.push({ name: warning.name, message: warning.message })
-        }
-        process.on('warning', listener)
+describe('suppressExperimentalWarningsSync', () => {
+    test('swallows ExperimentalWarning emissions during the synchronous call', () => {
+        const calls: unknown[][] = []
+        const originalEmit = process.emitWarning
+        process.emitWarning = ((...args: unknown[]) => {
+            calls.push(args)
+        }) as typeof process.emitWarning
+
         try {
-            await getDefaultDispatcher()
+            suppressExperimentalWarningsSync(() => {
+                process.emitWarning('experimental-string-form', 'ExperimentalWarning')
+                process.emitWarning('experimental-options-form', {
+                    type: 'ExperimentalWarning',
+                })
+                process.emitWarning('deprecation', 'DeprecationWarning')
+            })
         } finally {
-            process.off('warning', listener)
+            process.emitWarning = originalEmit
         }
 
-        const decompressWarnings = warnings.filter(
-            (w) => w.name === 'ExperimentalWarning' && w.message.includes('DecompressInterceptor'),
-        )
-        expect(decompressWarnings).toEqual([])
+        expect(calls).toHaveLength(1)
+        expect(calls[0]?.[0]).toBe('deprecation')
+    })
+
+    test('restores the original emitWarning even if the callback throws', () => {
+        const originalEmit = process.emitWarning
+        const placeholder = (() => {}) as typeof process.emitWarning
+        process.emitWarning = placeholder
+
+        try {
+            expect(() =>
+                suppressExperimentalWarningsSync(() => {
+                    throw new Error('boom')
+                }),
+            ).toThrow('boom')
+            expect(process.emitWarning).toBe(placeholder)
+        } finally {
+            process.emitWarning = originalEmit
+        }
+    })
+
+    test('returns the callback result', () => {
+        const result = suppressExperimentalWarningsSync(() => 42)
+        expect(result).toBe(42)
     })
 })

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -47,29 +47,47 @@ async function createDefaultDispatcher(): Promise<Dispatcher> {
     // `content-encoding` header but does not actually decompress the body,
     // so callers receive raw gzipped bytes and `JSON.parse` fails.
     // See https://github.com/Doist/todoist-cli/issues/318.
-    const decompress = silenceExperimentalWarning('DecompressInterceptor', () =>
-        interceptors.decompress(),
-    )
+    const decompress = suppressExperimentalWarningsSync(() => interceptors.decompress())
 
     return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS).compose(decompress)
 }
 
-// undici emits a one-time `ExperimentalWarning` the first time
-// `interceptors.decompress()` is called. The interceptor is fully implemented
-// and stable for our use case; suppress the warning so it does not leak to
-// every consumer's stderr on the first request.
-function silenceExperimentalWarning<T>(matchSubstring: string, fn: () => T): T {
+// undici emits an `ExperimentalWarning` the first time `interceptors.decompress()`
+// runs. The interceptor is stable for our gzipped-JSON-over-HTTPS use case;
+// silence the warning during dispatcher init only so it does not leak to every
+// consumer's stderr on the first request.
+//
+// `fn` must be synchronous so the override covers a single critical section
+// (microseconds) — no unrelated `ExperimentalWarning` from elsewhere can
+// interleave and be lost. We suppress every `ExperimentalWarning` rather than
+// pattern-matching the message text: the message wording is an undici
+// implementation detail (not a stable API), and the suppression window is
+// narrow enough that a coarse type filter is safe.
+//
+// Exported for direct unit testing — the integration path through
+// `getDefaultDispatcher()` cannot reliably exercise the helper because both
+// the dispatcher singleton and undici's internal `warningEmitted` flag are
+// once-per-process.
+export function suppressExperimentalWarningsSync<T>(fn: () => T): T {
     const originalEmit = process.emitWarning
-    process.emitWarning = ((warning: string | Error, ...rest: unknown[]) => {
-        const type = typeof rest[0] === 'string' ? rest[0] : undefined
-        if (
-            type === 'ExperimentalWarning' &&
-            typeof warning === 'string' &&
-            warning.includes(matchSubstring)
-        ) {
-            return
-        }
-        return (originalEmit as (...args: unknown[]) => void).call(process, warning, ...rest)
+    process.emitWarning = ((
+        warning: string | Error,
+        typeOrOptions?: string | { type?: string },
+        ...rest: unknown[]
+    ): void => {
+        const type =
+            typeof typeOrOptions === 'string'
+                ? typeOrOptions
+                : typeof typeOrOptions === 'object' && typeOrOptions !== null
+                  ? typeOrOptions.type
+                  : undefined
+        if (type === 'ExperimentalWarning') return
+        ;(originalEmit as (...args: unknown[]) => void).call(
+            process,
+            warning,
+            typeOrOptions,
+            ...rest,
+        )
     }) as typeof process.emitWarning
     try {
         return fn()

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -39,9 +39,43 @@ export async function resetDefaultDispatcherForTests(): Promise<void> {
 }
 
 async function createDefaultDispatcher(): Promise<Dispatcher> {
-    const { EnvHttpProxyAgent } = await import('undici')
+    const { EnvHttpProxyAgent, interceptors } = await import('undici')
 
-    return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
+    // Compose the response-decompression interceptor so gzip/deflate/br/zstd
+    // bodies are decoded before consumers parse them. Required on Node 24+:
+    // attaching any custom dispatcher to the global `fetch` strips the
+    // `content-encoding` header but does not actually decompress the body,
+    // so callers receive raw gzipped bytes and `JSON.parse` fails.
+    // See https://github.com/Doist/todoist-cli/issues/318.
+    const decompress = silenceExperimentalWarning('DecompressInterceptor', () =>
+        interceptors.decompress(),
+    )
+
+    return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS).compose(decompress)
+}
+
+// undici emits a one-time `ExperimentalWarning` the first time
+// `interceptors.decompress()` is called. The interceptor is fully implemented
+// and stable for our use case; suppress the warning so it does not leak to
+// every consumer's stderr on the first request.
+function silenceExperimentalWarning<T>(matchSubstring: string, fn: () => T): T {
+    const originalEmit = process.emitWarning
+    process.emitWarning = ((warning: string | Error, ...rest: unknown[]) => {
+        const type = typeof rest[0] === 'string' ? rest[0] : undefined
+        if (
+            type === 'ExperimentalWarning' &&
+            typeof warning === 'string' &&
+            warning.includes(matchSubstring)
+        ) {
+            return
+        }
+        return (originalEmit as (...args: unknown[]) => void).call(process, warning, ...rest)
+    }) as typeof process.emitWarning
+    try {
+        return fn()
+    } finally {
+        process.emitWarning = originalEmit
+    }
 }
 
 function isNodeEnvironment(): boolean {

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -39,6 +39,9 @@ export async function resetDefaultDispatcherForTests(): Promise<void> {
 }
 
 async function createDefaultDispatcher(): Promise<Dispatcher> {
+    // Dynamic import so non-Node consumers (browser, edge runtimes) don't pull
+    // undici into their bundle. `getDefaultDispatcher` already short-circuits
+    // outside Node, so this branch only runs when undici is safe to load.
     const { EnvHttpProxyAgent, interceptors } = await import('undici')
 
     // Compose the response-decompression interceptor so gzip/deflate/br/zstd


### PR DESCRIPTION
## Summary

- Compose undici's built-in `interceptors.decompress()` onto `EnvHttpProxyAgent` so `gzip`/`deflate`/`br`/`zstd` response bodies are decoded before reaching consumers.
- Suppress undici's one-time `ExperimentalWarning` for the decompress interceptor so it does not leak to every consumer's stderr.

## Problem

On Node 24+, attaching **any** custom dispatcher to global `fetch` strips the response's `content-encoding` header but does not actually decompress the body. Every `@doist/todoist-sdk` consumer running on Node 24+ (and especially Node 26) receives raw gzipped bytes; `JSON.parse` fails; the SDK's catch-all assigns the raw text to `response.data`; downstream Zod schemas reject at the root with messages like:

```
[{ "expected": "object", "code": "invalid_type", "path": [], "message": "Invalid input: expected object, received string" }]
```

This breaks every `td` command on Node 26 — see [Doist/todoist-cli#318](https://github.com/Doist/todoist-cli/issues/318).

## Fix

undici 7 ships a built-in `decompress` interceptor (public API: `undici.interceptors.decompress`) that handles gzip/deflate/br/zstd, strips `content-encoding`/`content-length` from upstream headers (so Node's fetch layer doesn't try to decompress again), and is composed via the standard `Dispatcher.prototype.compose(...)` API. ~1 line of dispatcher change; preserves wire compression (no `Accept-Encoding: identity` workaround, no bandwidth regression).

The undici interceptor is currently flagged `ExperimentalWarning` but is fully implemented and stable for HTTPS gzipped-JSON. The change includes a small `suppressExperimentalWarningsSync` helper (exported for direct unit testing) that suppresses every `ExperimentalWarning` during the synchronous dispatcher-init critical section. The synchronous contract is what makes the global `process.emitWarning` override safe — no unrelated code can interleave during the microsecond window.

## Why decompress over `Accept-Encoding: identity`

A previous attempt in the twist SDK ([Doist/twist-sdk-typescript#126](https://github.com/Doist/twist-sdk-typescript/pull/126)) sent `Accept-Encoding: identity` so the server skipped compression entirely. That works but trades wire bandwidth for simplicity; the larger Todoist sync responses gzip ~70-80%. Composing the interceptor is the proper fix and preserves compression.

The same fix is being applied to `@doist/twist-sdk` ([#128](https://github.com/Doist/twist-sdk-typescript/pull/128)) and `@doist/aist-sdk` ([#2](https://github.com/Doist/aist-sdk-typescript/pull/2)).

## Test plan

- [x] `npm test` — 579/579 passing, including new dispatcher coverage:
  - `decompresses gzip-encoded response bodies` — spins up a `node:http` server, returns `Content-Encoding: gzip` with raw gzipped JSON, verifies the SDK's dispatcher decodes it.
  - `suppressExperimentalWarningsSync` unit tests — directly verify the helper swallows both `emitWarning` signatures, restores the original on throw, and returns the callback result.
- [x] `npm run check` — oxlint + oxfmt pass
- [x] `npm run build`
- [x] Live verification on Node 26.1.0 by linking the built SDK into todoist-cli (`npm link @doist/todoist-sdk`):
  - `td auth status` — prints user (was failing with the Zod error above)
  - `td inbox` — lists tasks (was failing)
  - `td auth status 2>&1 | grep -i experimental` — empty (warning suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)