### PR TITLE
fix: Convert `uploadFile` response from snake_case to camelCase before validating

### DIFF
--- a/src/clients/app-client.ts
+++ b/src/clients/app-client.ts
@@ -186,7 +186,7 @@ export class AppClient extends BaseClient {
             throw new Error('Cannot upload empty image file')
         }
 
-        const data = await uploadMultipartFile<unknown>({
+        const data = await uploadMultipartFile({
             baseUrl: this.apiRootBase,
             authToken: this.authToken,
             endpoint: getAppIconEndpoint(appId, size),

--- a/src/clients/app-client.ts
+++ b/src/clients/app-client.ts
@@ -37,7 +37,6 @@ import type {
     UserAuthorization,
 } from '../types/apps'
 import { webhookEventToWireName } from '../types/apps'
-import { camelCaseKeys } from '../utils/case-conversion'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import {
     IdSchema,
@@ -197,7 +196,7 @@ export class AppClient extends BaseClient {
             requestId: requestId,
             customFetch: this.customFetch,
         })
-        return validateAppWithUserCount(camelCaseKeys(data))
+        return validateAppWithUserCount(data)
     }
 
     async getAppTestToken(appId: string, requestId?: string): Promise<AppTestToken> {

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -67,7 +67,7 @@ export class TemplateClient extends BaseClient {
             additionalFields.workspace_id = workspaceId
         }
 
-        const data = await uploadMultipartFile<Record<string, unknown>>({
+        const data = await uploadMultipartFile({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_REST_TEMPLATES_CREATE_FROM_FILE,
@@ -77,7 +77,9 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             requestId,
         })
-        return this.validateTemplateResponse(data) as CreateProjectFromTemplateResponse
+        return this.validateTemplateResponse(
+            data as Record<string, unknown>,
+        ) as CreateProjectFromTemplateResponse
     }
 
     async importTemplateIntoProject(
@@ -85,7 +87,7 @@ export class TemplateClient extends BaseClient {
         requestId?: string,
     ): Promise<ImportTemplateResponse> {
         const { file, fileName, projectId } = args
-        const data = await uploadMultipartFile<Record<string, unknown>>({
+        const data = await uploadMultipartFile({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_REST_TEMPLATES_IMPORT_FROM_FILE,
@@ -95,7 +97,9 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             requestId,
         })
-        return this.validateTemplateResponse(data) as ImportTemplateResponse
+        return this.validateTemplateResponse(
+            data as Record<string, unknown>,
+        ) as ImportTemplateResponse
     }
 
     async importTemplateFromId(

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -16,7 +16,6 @@ import type {
     ImportTemplateIntoProjectArgs,
     ImportTemplateResponse,
 } from '../types/templates'
-import { camelCaseKeys } from '../utils/case-conversion'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import {
     validateCommentArray,
@@ -78,9 +77,7 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             requestId,
         })
-        return this.validateTemplateResponse(
-            camelCaseKeys(data),
-        ) as CreateProjectFromTemplateResponse
+        return this.validateTemplateResponse(data) as CreateProjectFromTemplateResponse
     }
 
     async importTemplateIntoProject(
@@ -98,7 +95,7 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             requestId,
         })
-        return this.validateTemplateResponse(camelCaseKeys(data)) as ImportTemplateResponse
+        return this.validateTemplateResponse(data) as ImportTemplateResponse
     }
 
     async importTemplateFromId(

--- a/src/clients/ui-extension-client.ts
+++ b/src/clients/ui-extension-client.ts
@@ -114,7 +114,7 @@ export class UiExtensionClient extends BaseClient {
             throw new Error('Cannot upload empty image file')
         }
 
-        const data = await uploadMultipartFile<unknown>({
+        const data = await uploadMultipartFile({
             baseUrl: this.apiRootBase,
             authToken: this.authToken,
             endpoint: getUiExtensionIconEndpoint(args.uiExtensionId),

--- a/src/clients/ui-extension-client.ts
+++ b/src/clients/ui-extension-client.ts
@@ -12,7 +12,6 @@ import type {
     UpdateUiExtensionArgs,
     UploadUiExtensionIconArgs,
 } from '../types/ui-extensions'
-import { camelCaseKeys } from '../utils/case-conversion'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { IdSchema, validateUiExtension, validateUiExtensionArray } from '../utils/validators'
 import { BaseClient } from './base-client'
@@ -125,6 +124,6 @@ export class UiExtensionClient extends BaseClient {
             requestId: requestId,
             customFetch: this.customFetch,
         })
-        return validateUiExtension(camelCaseKeys(data))
+        return validateUiExtension(data)
     }
 }

--- a/src/clients/upload-client.ts
+++ b/src/clients/upload-client.ts
@@ -3,7 +3,6 @@ import { isSuccess, request } from '../transport/http-client'
 import type { Attachment, Comment } from '../types/comments'
 import type { FileResponse } from '../types/http'
 import type { DeleteUploadArgs, UploadFileArgs } from '../types/uploads'
-import { camelCaseKeys } from '../utils/case-conversion'
 import { headersToRecord } from '../utils/headers'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { validateAttachment } from '../utils/validators'
@@ -24,7 +23,7 @@ export class UploadClient extends BaseClient {
             additionalFields.project_id = args.projectId
         }
 
-        const data = await uploadMultipartFile<Record<string, unknown>>({
+        const data = await uploadMultipartFile<Attachment>({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_REST_UPLOADS,
@@ -35,7 +34,7 @@ export class UploadClient extends BaseClient {
             customFetch: this.customFetch,
         })
 
-        return validateAttachment(camelCaseKeys(data))
+        return validateAttachment(data)
     }
 
     async deleteUpload(args: DeleteUploadArgs, requestId?: string): Promise<boolean> {

--- a/src/clients/upload-client.ts
+++ b/src/clients/upload-client.ts
@@ -23,7 +23,7 @@ export class UploadClient extends BaseClient {
             additionalFields.project_id = args.projectId
         }
 
-        const data = await uploadMultipartFile<Attachment>({
+        const data = await uploadMultipartFile({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_REST_UPLOADS,

--- a/src/clients/upload-client.ts
+++ b/src/clients/upload-client.ts
@@ -3,6 +3,7 @@ import { isSuccess, request } from '../transport/http-client'
 import type { Attachment, Comment } from '../types/comments'
 import type { FileResponse } from '../types/http'
 import type { DeleteUploadArgs, UploadFileArgs } from '../types/uploads'
+import { camelCaseKeys } from '../utils/case-conversion'
 import { headersToRecord } from '../utils/headers'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { validateAttachment } from '../utils/validators'
@@ -23,7 +24,7 @@ export class UploadClient extends BaseClient {
             additionalFields.project_id = args.projectId
         }
 
-        const data = await uploadMultipartFile<Attachment>({
+        const data = await uploadMultipartFile<Record<string, unknown>>({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_REST_UPLOADS,
@@ -34,7 +35,7 @@ export class UploadClient extends BaseClient {
             customFetch: this.customFetch,
         })
 
-        return validateAttachment(data)
+        return validateAttachment(camelCaseKeys(data))
     }
 
     async deleteUpload(args: DeleteUploadArgs, requestId?: string): Promise<boolean> {

--- a/src/clients/workspace-client.ts
+++ b/src/clients/workspace-client.ts
@@ -188,7 +188,7 @@ export class WorkspaceClient extends BaseClient {
     ): Promise<WorkspaceLogoResponse> {
         if (args.delete) {
             // Delete logo
-            const data = await uploadMultipartFile<WorkspaceLogoResponse>({
+            const data = await uploadMultipartFile({
                 baseUrl: this.syncApiBase,
                 authToken: this.authToken,
                 endpoint: ENDPOINT_WORKSPACE_LOGO,
@@ -201,7 +201,7 @@ export class WorkspaceClient extends BaseClient {
                 requestId: requestId,
                 customFetch: this.customFetch,
             })
-            return data
+            return data as WorkspaceLogoResponse
         }
 
         if (!args.file) {
@@ -217,7 +217,7 @@ export class WorkspaceClient extends BaseClient {
             workspace_id: args.workspaceId,
         }
 
-        const data = await uploadMultipartFile<WorkspaceLogoResponse>({
+        const data = await uploadMultipartFile({
             baseUrl: this.syncApiBase,
             authToken: this.authToken,
             endpoint: ENDPOINT_WORKSPACE_LOGO,
@@ -228,7 +228,7 @@ export class WorkspaceClient extends BaseClient {
             customFetch: this.customFetch,
         })
 
-        return data
+        return data as WorkspaceLogoResponse
     }
 
     async getWorkspacePlanDetails(

--- a/src/todoist-api.uploads.test.ts
+++ b/src/todoist-api.uploads.test.ts
@@ -160,10 +160,6 @@ describe('TodoistApi uploads', () => {
         })
 
         test('camelCases snake_case keys returned by the API', async () => {
-            // The real upload endpoint returns snake_case (e.g. `file_url`,
-            // `resource_type`). Without conversion, `validateAttachment` would
-            // reject the response because `AttachmentSchema` requires
-            // camelCase keys.
             server.use(
                 http.post(`${getSyncBaseUri()}uploads`, () =>
                     HttpResponse.json(

--- a/src/todoist-api.uploads.test.ts
+++ b/src/todoist-api.uploads.test.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest'
 import { getSyncBaseUri } from './consts/endpoints'
 import { server, http, HttpResponse, getLastRequest, captureRequest } from './test-utils/msw-setup'
 import { TodoistApi } from './todoist-api'
+import { snakeCaseKeys } from './utils/case-conversion'
 
 // Mock fs
 vi.mock('fs')
@@ -34,7 +35,7 @@ describe('TodoistApi uploads', () => {
                         // FormData parsing might fail in test environment
                     }
                     captureRequest({ request, body })
-                    return HttpResponse.json(mockUploadResult, { status: 200 })
+                    return HttpResponse.json(snakeCaseKeys(mockUploadResult), { status: 200 })
                 }),
             )
         })
@@ -157,45 +158,6 @@ describe('TodoistApi uploads', () => {
 
             const capturedRequest = getLastRequest()
             expect(capturedRequest).toBeDefined()
-        })
-
-        test('camelCases snake_case keys returned by the API', async () => {
-            server.use(
-                http.post(`${getSyncBaseUri()}uploads`, () =>
-                    HttpResponse.json(
-                        {
-                            file_url: 'https://cdn.todoist.com/uploads/snake.pdf',
-                            file_name: 'snake.pdf',
-                            file_size: 2048,
-                            file_type: 'application/pdf',
-                            resource_type: 'file',
-                            upload_state: 'completed',
-                            image: null,
-                            image_width: null,
-                            image_height: null,
-                        },
-                        { status: 200 },
-                    ),
-                ),
-            )
-
-            const api = new TodoistApi('token')
-            const result = await api.uploadFile({
-                file: Buffer.from('test file content'),
-                fileName: 'snake.pdf',
-            })
-
-            expect(result).toEqual({
-                fileUrl: 'https://cdn.todoist.com/uploads/snake.pdf',
-                fileName: 'snake.pdf',
-                fileSize: 2048,
-                fileType: 'application/pdf',
-                resourceType: 'file',
-                uploadState: 'completed',
-                image: null,
-                imageWidth: null,
-                imageHeight: null,
-            })
         })
     })
 

--- a/src/todoist-api.uploads.test.ts
+++ b/src/todoist-api.uploads.test.ts
@@ -158,6 +158,49 @@ describe('TodoistApi uploads', () => {
             const capturedRequest = getLastRequest()
             expect(capturedRequest).toBeDefined()
         })
+
+        test('camelCases snake_case keys returned by the API', async () => {
+            // The real upload endpoint returns snake_case (e.g. `file_url`,
+            // `resource_type`). Without conversion, `validateAttachment` would
+            // reject the response because `AttachmentSchema` requires
+            // camelCase keys.
+            server.use(
+                http.post(`${getSyncBaseUri()}uploads`, () =>
+                    HttpResponse.json(
+                        {
+                            file_url: 'https://cdn.todoist.com/uploads/snake.pdf',
+                            file_name: 'snake.pdf',
+                            file_size: 2048,
+                            file_type: 'application/pdf',
+                            resource_type: 'file',
+                            upload_state: 'completed',
+                            image: null,
+                            image_width: null,
+                            image_height: null,
+                        },
+                        { status: 200 },
+                    ),
+                ),
+            )
+
+            const api = new TodoistApi('token')
+            const result = await api.uploadFile({
+                file: Buffer.from('test file content'),
+                fileName: 'snake.pdf',
+            })
+
+            expect(result).toEqual({
+                fileUrl: 'https://cdn.todoist.com/uploads/snake.pdf',
+                fileName: 'snake.pdf',
+                fileSize: 2048,
+                fileType: 'application/pdf',
+                resourceType: 'file',
+                uploadState: 'completed',
+                image: null,
+                imageWidth: null,
+                imageHeight: null,
+            })
+        })
     })
 
     describe('deleteUpload', () => {

--- a/src/utils/multipart-upload.test.ts
+++ b/src/utils/multipart-upload.test.ts
@@ -234,4 +234,38 @@ describe('uploadMultipartFile', () => {
             expect(capturedRequest?.headers['x-request-id']).toBeUndefined()
         })
     })
+
+    describe('response conversion', () => {
+        test('camelCases snake_case keys returned by the server', async () => {
+            server.use(
+                http.post(`${baseUrl}${endpoint}`, () =>
+                    HttpResponse.json(
+                        {
+                            file_url: 'https://example.com/file.pdf',
+                            file_name: 'file.pdf',
+                            resource_type: 'file',
+                            nested_object: { inner_key: 'value' },
+                        },
+                        { status: 200 },
+                    ),
+                ),
+            )
+
+            const result = await uploadMultipartFile({
+                baseUrl: baseUrl,
+                authToken: authToken,
+                endpoint: endpoint,
+                file: Buffer.from('test'),
+                fileName: 'test.pdf',
+                additionalFields: {},
+            })
+
+            expect(result).toEqual({
+                fileUrl: 'https://example.com/file.pdf',
+                fileName: 'file.pdf',
+                resourceType: 'file',
+                nestedObject: { innerKey: 'value' },
+            })
+        })
+    })
 })

--- a/src/utils/multipart-upload.ts
+++ b/src/utils/multipart-upload.ts
@@ -1,5 +1,6 @@
 import { fetchWithRetry } from '../transport/fetch-with-retry'
 import type { HttpResponse, CustomFetch } from '../types/http'
+import { camelCaseKeys } from './case-conversion'
 
 type UploadMultipartFileArgs = {
     baseUrl: string
@@ -160,7 +161,7 @@ export async function uploadMultipartFile<T>(args: UploadMultipartFileArgs): Pro
     }
 
     // Make the request using fetch
-    const response: HttpResponse<T> = await fetchWithRetry({
+    const response: HttpResponse<unknown> = await fetchWithRetry({
         url,
         options: {
             method: 'POST',
@@ -171,5 +172,5 @@ export async function uploadMultipartFile<T>(args: UploadMultipartFileArgs): Pro
         customFetch,
     })
 
-    return response.data
+    return camelCaseKeys(response.data) as T
 }

--- a/src/utils/multipart-upload.ts
+++ b/src/utils/multipart-upload.ts
@@ -78,7 +78,7 @@ function getContentTypeFromFileName(fileName: string): string {
  * )
  * ```
  */
-export async function uploadMultipartFile<T>(args: UploadMultipartFileArgs): Promise<T> {
+export async function uploadMultipartFile(args: UploadMultipartFileArgs): Promise<unknown> {
     const {
         baseUrl,
         authToken,
@@ -172,5 +172,5 @@ export async function uploadMultipartFile<T>(args: UploadMultipartFileArgs): Pro
         customFetch,
     })
 
-    return camelCaseKeys(response.data) as T
+    return camelCaseKeys(response.data)
 }


### PR DESCRIPTION
## Summary

### Problem

`upload-file` was passing the raw API response (snake_case: `file_url`, `resource_type`, …) straight to `validateAttachment`, but `AttachmentSchema` requires camelCase. Result: every real upload threw a Zod validation error because `resource_type` never landed on `resourceType` (discovered while testing https://github.com/Doist/todoist-cli/pull/337).

### Solution

Rather than patching `upload-client`, this PR fixes the root cause:

- **Centralize the conversion in `uploadMultipartFile`** so multipart responses are normalized at the transport boundary, matching what `request()` already does for JSON responses. New multipart endpoints can't forget the step anymore
- **Drop the now-redundant `camelCaseKeys(...)` wrappers** from `app-client`, `template-client`, and `ui-extension-client`

## Reference

- Needed [here](https://github.com/Doist/todoist-cli/pull/337/changes#r3235966660) to fix https://github.com/Doist/Issues/issues/20242
- Blocks https://github.com/Doist/todoist-cli/pull/337

## Test plan

- [ ] CI passes