### PR TITLE
feat: add template gallery read endpoints to TemplateClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "zod": "4.3.6"
             },
             "devDependencies": {
+                "@arethetypeswrong/cli": "0.18.2",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/git": "10.0.1",
                 "conventional-changelog-conventionalcommits": "9.3.1",
@@ -92,6 +93,115 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@andrewbranch/untar.js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+            "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+            "dev": true
+        },
+        "node_modules/@arethetypeswrong/cli": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.2.tgz",
+            "integrity": "sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@arethetypeswrong/core": "0.18.2",
+                "chalk": "^4.1.2",
+                "cli-table3": "^0.6.3",
+                "commander": "^10.0.1",
+                "marked": "^9.1.2",
+                "marked-terminal": "^7.1.0",
+                "semver": "^7.5.4"
+            },
+            "bin": {
+                "attw": "dist/index.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@arethetypeswrong/cli/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@arethetypeswrong/cli/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@arethetypeswrong/cli/node_modules/marked": {
+            "version": "9.1.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+            "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 16"
+            }
+        },
+        "node_modules/@arethetypeswrong/core": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
+            "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@andrewbranch/untar.js": "^1.0.3",
+                "@loaderkit/resolve": "^1.0.2",
+                "cjs-module-lexer": "^1.2.3",
+                "fflate": "^0.8.2",
+                "lru-cache": "^11.0.1",
+                "semver": "^7.5.4",
+                "typescript": "5.6.1-rc",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+            "version": "5.6.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+            "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -116,6 +226,13 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@braidai/lang": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+            "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@codemirror/state": {
             "version": "6.5.0",
@@ -783,6 +900,16 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@loaderkit/resolve": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.5.tgz",
+            "integrity": "sha512-fhkdGM57xhJ7CO91MUgbQlb0ClP0AJ9vB3yoVnBTslYJqrJOCVEbOprZcxZlexdMbmTBPQqVcQYr+j4oRRtIZA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@braidai/lang": "^1.0.0"
             }
         },
         "node_modules/@marijn/find-cluster-break": {
@@ -3017,6 +3144,13 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/clean-stack": {
             "version": "2.2.0",
@@ -9502,6 +9636,16 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "node_modules/validate-npm-package-name": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/vite": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
@@ -9927,6 +10071,81 @@
             "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
             "dev": true
         },
+        "@andrewbranch/untar.js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+            "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+            "dev": true
+        },
+        "@arethetypeswrong/cli": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.2.tgz",
+            "integrity": "sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==",
+            "dev": true,
+            "requires": {
+                "@arethetypeswrong/core": "0.18.2",
+                "chalk": "^4.1.2",
+                "cli-table3": "^0.6.3",
+                "commander": "^10.0.1",
+                "marked": "^9.1.2",
+                "marked-terminal": "^7.1.0",
+                "semver": "^7.5.4"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "commander": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+                    "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+                    "dev": true
+                },
+                "marked": {
+                    "version": "9.1.6",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+                    "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+                    "dev": true
+                }
+            }
+        },
+        "@arethetypeswrong/core": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
+            "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+            "dev": true,
+            "requires": {
+                "@andrewbranch/untar.js": "^1.0.3",
+                "@loaderkit/resolve": "^1.0.2",
+                "cjs-module-lexer": "^1.2.3",
+                "fflate": "0.8.2",
+                "lru-cache": "^11.0.1",
+                "semver": "^7.5.4",
+                "typescript": "5.6.1-rc",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "dependencies": {
+                "fflate": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+                    "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+                    "dev": true
+                },
+                "typescript": {
+                    "version": "5.6.1-rc",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+                    "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/code-frame": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -9942,6 +10161,12 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true
+        },
+        "@braidai/lang": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+            "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
             "dev": true
         },
         "@codemirror/state": {
@@ -10295,6 +10520,15 @@
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@loaderkit/resolve": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.5.tgz",
+            "integrity": "sha512-fhkdGM57xhJ7CO91MUgbQlb0ClP0AJ9vB3yoVnBTslYJqrJOCVEbOprZcxZlexdMbmTBPQqVcQYr+j4oRRtIZA==",
+            "dev": true,
+            "requires": {
+                "@braidai/lang": "^1.0.0"
             }
         },
         "@marijn/find-cluster-break": {
@@ -11595,6 +11829,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
+        },
+        "cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "dev": true
         },
         "clean-stack": {
@@ -15849,6 +16089,12 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "validate-npm-package-name": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+            "dev": true
         },
         "vite": {
             "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,13 @@
         "build:fix-dts": "node scripts/fix-dts-imports.cjs",
         "build:post": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "build": "npm-run-all clean build:cjs build:esm build:fix-esm build:fix-dts build:post",
-        "attw": "npx @arethetypeswrong/cli --pack --ignore-rules fallback-condition false-esm",
+        "attw": "attw --pack --ignore-rules fallback-condition false-esm",
         "integrity-checks": "npm-run-all clean check test build attw",
         "prepublishOnly": "npm run integrity-checks",
         "prepare": "npm run build"
+    },
+    "overrides": {
+        "fflate": "0.8.2"
     },
     "dependencies": {
         "camelcase": "6.3.0",
@@ -56,6 +59,7 @@
         "zod": "4.3.6"
     },
     "devDependencies": {
+        "@arethetypeswrong/cli": "0.18.2",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "conventional-changelog-conventionalcommits": "9.3.1",

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -9,7 +9,7 @@ import {
     ENDPOINT_REST_TEMPLATES_URL,
 } from '../consts/endpoints'
 import { request } from '../transport/http-client'
-import { TodoistArgumentError, TodoistRequestError } from '../types/errors'
+import { TodoistArgumentError } from '../types/errors'
 import type {
     CreateProjectFromTemplateArgs,
     CreateProjectFromTemplateResponse,
@@ -25,37 +25,21 @@ import type {
     ImportTemplateFromIdArgs,
     ImportTemplateIntoProjectArgs,
     ImportTemplateResponse,
-    Template,
 } from '../types/templates'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { spreadIfDefined } from '../utils/request-helpers'
 import {
     validateCommentArray,
+    validateGetTemplateCategoriesResponse,
+    validateGetTemplatesByIdsResponse,
+    validateGetTemplatesResponse,
     validateProjectArray,
     validateSectionArray,
     validateTaskArray,
-    validateTemplate,
-    validateTemplateArray,
-    validateTemplateCategoryArray,
 } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 const TEMPLATES_BY_IDS_MAX = 100
-
-type RawGetTemplatesResponse = {
-    templates: unknown
-    count: number
-    hasMore: boolean
-    nextCursor?: string
-}
-
-type RawGetTemplateCategoriesResponse = {
-    categories: unknown
-}
-
-type RawGetTemplatesByIdsResponse = {
-    templates?: unknown
-}
 
 /**
  * Internal sub-client handling all template-domain endpoints.
@@ -151,7 +135,7 @@ export class TemplateClient extends BaseClient {
     }
 
     async getTemplates(args: GetTemplatesArgs = {}): Promise<GetTemplatesResponse> {
-        const { data } = await request<RawGetTemplatesResponse>({
+        const { data } = await request<GetTemplatesResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_LIST,
@@ -159,18 +143,13 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             payload: args,
         })
-        return {
-            templates: validateTemplateArray(data.templates),
-            count: data.count,
-            hasMore: data.hasMore,
-            ...spreadIfDefined(data.nextCursor, (v) => ({ nextCursor: v })),
-        }
+        return validateGetTemplatesResponse(data)
     }
 
     async getTemplateCategories(
         args: GetTemplateCategoriesArgs = {},
     ): Promise<GetTemplateCategoriesResponse> {
-        const { data } = await request<RawGetTemplateCategoriesResponse>({
+        const { data } = await request<GetTemplateCategoriesResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_CATEGORIES,
@@ -178,7 +157,7 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             payload: args,
         })
-        return { categories: validateTemplateCategoryArray(data.categories) }
+        return validateGetTemplateCategoriesResponse(data)
     }
 
     async getTemplatesByIds(args: GetTemplatesByIdsArgs): Promise<GetTemplatesByIdsResponse> {
@@ -195,7 +174,7 @@ export class TemplateClient extends BaseClient {
             throw new TodoistArgumentError('templateIds must contain only non-empty strings.')
         }
 
-        const { data } = await request<RawGetTemplatesByIdsResponse>({
+        const { data } = await request<GetTemplatesByIdsResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_GET,
@@ -206,24 +185,7 @@ export class TemplateClient extends BaseClient {
                 ...spreadIfDefined(locale, (v) => ({ locale: v })),
             },
         })
-
-        if (
-            data.templates === null ||
-            data.templates === undefined ||
-            typeof data.templates !== 'object' ||
-            Array.isArray(data.templates)
-        ) {
-            throw new TodoistRequestError(
-                'Invalid response from /templates/get: expected `templates` to be an object.',
-            )
-        }
-
-        const validated: Record<string, Template> = {}
-        for (const template of Object.values(data.templates as Record<string, unknown>)) {
-            const valid = validateTemplate(template)
-            validated[valid.id] = valid
-        }
-        return { templates: validated }
+        return validateGetTemplatesByIdsResponse(data)
     }
 
     private validateTemplateResponse(data: Record<string, unknown>) {

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -9,6 +9,7 @@ import {
     ENDPOINT_REST_TEMPLATES_URL,
 } from '../consts/endpoints'
 import { request } from '../transport/http-client'
+import { TodoistArgumentError, TodoistRequestError } from '../types/errors'
 import type {
     CreateProjectFromTemplateArgs,
     CreateProjectFromTemplateResponse,
@@ -27,6 +28,7 @@ import type {
     Template,
 } from '../types/templates'
 import { uploadMultipartFile } from '../utils/multipart-upload'
+import { spreadIfDefined } from '../utils/request-helpers'
 import {
     validateCommentArray,
     validateProjectArray,
@@ -37,6 +39,23 @@ import {
     validateTemplateCategoryArray,
 } from '../utils/validators'
 import { BaseClient } from './base-client'
+
+const TEMPLATES_BY_IDS_MAX = 100
+
+type RawGetTemplatesResponse = {
+    templates: unknown
+    count: number
+    hasMore: boolean
+    nextCursor?: string
+}
+
+type RawGetTemplateCategoriesResponse = {
+    categories: unknown
+}
+
+type RawGetTemplatesByIdsResponse = {
+    templates?: unknown
+}
 
 /**
  * Internal sub-client handling all template-domain endpoints.
@@ -132,7 +151,7 @@ export class TemplateClient extends BaseClient {
     }
 
     async getTemplates(args: GetTemplatesArgs = {}): Promise<GetTemplatesResponse> {
-        const { data } = await request<GetTemplatesResponse>({
+        const { data } = await request<RawGetTemplatesResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_LIST,
@@ -140,13 +159,18 @@ export class TemplateClient extends BaseClient {
             customFetch: this.customFetch,
             payload: args,
         })
-        return { ...data, templates: validateTemplateArray(data.templates) }
+        return {
+            templates: validateTemplateArray(data.templates),
+            count: data.count,
+            hasMore: data.hasMore,
+            ...spreadIfDefined(data.nextCursor, (v) => ({ nextCursor: v })),
+        }
     }
 
     async getTemplateCategories(
         args: GetTemplateCategoriesArgs = {},
     ): Promise<GetTemplateCategoriesResponse> {
-        const { data } = await request<GetTemplateCategoriesResponse>({
+        const { data } = await request<RawGetTemplateCategoriesResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_CATEGORIES,
@@ -159,16 +183,43 @@ export class TemplateClient extends BaseClient {
 
     async getTemplatesByIds(args: GetTemplatesByIdsArgs): Promise<GetTemplatesByIdsResponse> {
         const { templateIds, locale } = args
-        const { data } = await request<GetTemplatesByIdsResponse>({
+        if (!Array.isArray(templateIds) || templateIds.length === 0) {
+            throw new TodoistArgumentError('templateIds must be a non-empty array.')
+        }
+        if (templateIds.length > TEMPLATES_BY_IDS_MAX) {
+            throw new TodoistArgumentError(
+                `templateIds may contain at most ${TEMPLATES_BY_IDS_MAX} IDs (received ${templateIds.length}).`,
+            )
+        }
+        if (templateIds.some((id) => typeof id !== 'string' || id.length === 0)) {
+            throw new TodoistArgumentError('templateIds must contain only non-empty strings.')
+        }
+
+        const { data } = await request<RawGetTemplatesByIdsResponse>({
             httpMethod: 'GET',
             baseUri: this.syncApiBase,
             relativePath: ENDPOINT_REST_TEMPLATES_GET,
             apiToken: this.authToken,
             customFetch: this.customFetch,
-            payload: { templateIds: templateIds.join(','), ...(locale ? { locale } : {}) },
+            payload: {
+                templateIds: templateIds.join(','),
+                ...spreadIfDefined(locale, (v) => ({ locale: v })),
+            },
         })
+
+        if (
+            data.templates === null ||
+            data.templates === undefined ||
+            typeof data.templates !== 'object' ||
+            Array.isArray(data.templates)
+        ) {
+            throw new TodoistRequestError(
+                'Invalid response from /templates/get: expected `templates` to be an object.',
+            )
+        }
+
         const validated: Record<string, Template> = {}
-        for (const template of Object.values(data.templates ?? {})) {
+        for (const template of Object.values(data.templates as Record<string, unknown>)) {
             const valid = validateTemplate(template)
             validated[valid.id] = valid
         }

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -1,8 +1,11 @@
 import {
+    ENDPOINT_REST_TEMPLATES_CATEGORIES,
     ENDPOINT_REST_TEMPLATES_CREATE_FROM_FILE,
     ENDPOINT_REST_TEMPLATES_FILE,
+    ENDPOINT_REST_TEMPLATES_GET,
     ENDPOINT_REST_TEMPLATES_IMPORT_FROM_FILE,
     ENDPOINT_REST_TEMPLATES_IMPORT_FROM_ID,
+    ENDPOINT_REST_TEMPLATES_LIST,
     ENDPOINT_REST_TEMPLATES_URL,
 } from '../consts/endpoints'
 import { request } from '../transport/http-client'
@@ -12,9 +15,16 @@ import type {
     ExportTemplateFileArgs,
     ExportTemplateUrlArgs,
     ExportTemplateUrlResponse,
+    GetTemplateCategoriesArgs,
+    GetTemplateCategoriesResponse,
+    GetTemplatesArgs,
+    GetTemplatesByIdsArgs,
+    GetTemplatesByIdsResponse,
+    GetTemplatesResponse,
     ImportTemplateFromIdArgs,
     ImportTemplateIntoProjectArgs,
     ImportTemplateResponse,
+    Template,
 } from '../types/templates'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import {
@@ -22,6 +32,9 @@ import {
     validateProjectArray,
     validateSectionArray,
     validateTaskArray,
+    validateTemplate,
+    validateTemplateArray,
+    validateTemplateCategoryArray,
 } from '../utils/validators'
 import { BaseClient } from './base-client'
 
@@ -116,6 +129,50 @@ export class TemplateClient extends BaseClient {
             requestId: requestId,
         })
         return this.validateTemplateResponse(data) as ImportTemplateResponse
+    }
+
+    async getTemplates(args: GetTemplatesArgs = {}): Promise<GetTemplatesResponse> {
+        const { data } = await request<GetTemplatesResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_TEMPLATES_LIST,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+        })
+        return { ...data, templates: validateTemplateArray(data.templates) }
+    }
+
+    async getTemplateCategories(
+        args: GetTemplateCategoriesArgs = {},
+    ): Promise<GetTemplateCategoriesResponse> {
+        const { data } = await request<GetTemplateCategoriesResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_TEMPLATES_CATEGORIES,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+        })
+        return { categories: validateTemplateCategoryArray(data.categories) }
+    }
+
+    async getTemplatesByIds(args: GetTemplatesByIdsArgs): Promise<GetTemplatesByIdsResponse> {
+        const { templateIds, locale } = args
+        const { data } = await request<GetTemplatesByIdsResponse>({
+            httpMethod: 'GET',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_TEMPLATES_GET,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: { templateIds: templateIds.join(','), ...(locale ? { locale } : {}) },
+        })
+        const validated: Record<string, Template> = {}
+        for (const template of Object.values(data.templates ?? {})) {
+            const valid = validateTemplate(template)
+            validated[valid.id] = valid
+        }
+        return { templates: validated }
     }
 
     private validateTemplateResponse(data: Record<string, unknown>) {

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -68,6 +68,9 @@ export const ENDPOINT_REST_TEMPLATES_CREATE_FROM_FILE = 'templates/create_projec
 export const ENDPOINT_REST_TEMPLATES_IMPORT_FROM_FILE = 'templates/import_into_project_from_file'
 export const ENDPOINT_REST_TEMPLATES_IMPORT_FROM_ID =
     'templates/import_into_project_from_template_id'
+export const ENDPOINT_REST_TEMPLATES_LIST = 'templates/list'
+export const ENDPOINT_REST_TEMPLATES_CATEGORIES = 'templates/categories'
+export const ENDPOINT_REST_TEMPLATES_GET = 'templates/get'
 
 export const ENDPOINT_REST_ACCESS_TOKENS_MIGRATE = 'access_tokens/migrate_personal_token'
 export const ENDPOINT_REST_BACKUPS = 'backups'

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -143,6 +143,173 @@ describe('TodoistApi template endpoints', () => {
         })
     })
 
+    describe('getTemplates', () => {
+        const MOCK_TEMPLATE_API = {
+            id: 'product-launch',
+            name: 'Product launch',
+            template_type: 'project',
+            template_source: 'doist',
+            short_description: 'Ship faster',
+            long_description: 'A reusable checklist for product launches.',
+            instructions: null,
+            import_url: null,
+            view_type: 'list',
+            thumbnail_image: null,
+            thumbnail_image_dark: null,
+            cover_image: null,
+            preview_image: null,
+            template_color: null,
+            background_color: null,
+            background_color_dark: null,
+            creator: { name: 'Doist', position: 'Team', avatar: '' },
+            seo: null,
+            more_resources: [],
+            category_ids: ['productivity'],
+        }
+
+        test('returns validated, camelCased list with pagination metadata', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}templates/list`, () => {
+                    return HttpResponse.json(
+                        {
+                            templates: [MOCK_TEMPLATE_API],
+                            count: 1,
+                            has_more: true,
+                            next_cursor: 'abc',
+                        },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.getTemplates({ templateType: 'project', limit: 1 })
+
+            expect(result.count).toBe(1)
+            expect(result.hasMore).toBe(true)
+            expect(result.nextCursor).toBe('abc')
+            expect(result.templates).toHaveLength(1)
+            expect(result.templates[0]).toMatchObject({
+                id: 'product-launch',
+                templateType: 'project',
+                templateSource: 'doist',
+                shortDescription: 'Ship faster',
+                categoryIds: ['productivity'],
+            })
+        })
+
+        test('forwards filter args as snake_case query params', async () => {
+            let observedUrl = ''
+            server.use(
+                http.get(`${getSyncBaseUri()}templates/list`, ({ request }) => {
+                    observedUrl = request.url
+                    return HttpResponse.json(
+                        { templates: [], count: 0, has_more: false },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            await api.getTemplates({
+                templateType: 'all',
+                templateSource: 'workspace',
+                categoryId: 'productivity',
+                cursor: 'cur_1',
+            })
+
+            expect(observedUrl).toContain('template_type=all')
+            expect(observedUrl).toContain('template_source=workspace')
+            expect(observedUrl).toContain('category_id=productivity')
+            expect(observedUrl).toContain('cursor=cur_1')
+        })
+    })
+
+    describe('getTemplateCategories', () => {
+        test('returns validated categories', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}templates/categories`, () => {
+                    return HttpResponse.json(
+                        {
+                            categories: [
+                                {
+                                    id: 'productivity',
+                                    name: 'Productivity',
+                                    description: 'Get things done.',
+                                    seo: { title: 'Productivity', description: null },
+                                },
+                            ],
+                        },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.getTemplateCategories({ locale: 'en' })
+
+            expect(result.categories).toHaveLength(1)
+            expect(result.categories[0]).toMatchObject({
+                id: 'productivity',
+                name: 'Productivity',
+                seo: { title: 'Productivity', description: null },
+            })
+        })
+    })
+
+    describe('getTemplatesByIds', () => {
+        test('joins template ids into CSV and validates each value in the response map', async () => {
+            let observedUrl = ''
+            server.use(
+                http.get(`${getSyncBaseUri()}templates/get`, ({ request }) => {
+                    observedUrl = request.url
+                    return HttpResponse.json(
+                        {
+                            templates: {
+                                'product-launch': {
+                                    id: 'product-launch',
+                                    name: 'Product launch',
+                                    template_type: 'project',
+                                    template_source: 'doist',
+                                    short_description: 'Ship faster',
+                                    long_description: 'desc',
+                                    instructions: null,
+                                    import_url: null,
+                                    thumbnail_image: null,
+                                    thumbnail_image_dark: null,
+                                    cover_image: null,
+                                    preview_image: null,
+                                    template_color: null,
+                                    background_color: null,
+                                    background_color_dark: null,
+                                    creator: { name: 'Doist', position: 'Team', avatar: '' },
+                                    seo: null,
+                                    more_resources: [],
+                                    category_ids: [],
+                                },
+                            },
+                        },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.getTemplatesByIds({
+                templateIds: ['product-launch', 'sprint-planning'],
+                locale: 'en',
+            })
+
+            expect(observedUrl).toContain('template_ids=product-launch%2Csprint-planning')
+            expect(observedUrl).toContain('locale=en')
+            expect(Object.keys(result.templates)).toEqual(['product-launch'])
+            expect(result.templates['product-launch']).toMatchObject({
+                id: 'product-launch',
+                shortDescription: 'Ship faster',
+            })
+        })
+    })
+
     describe('importTemplateFromId', () => {
         test('returns import result from rest client', async () => {
             const mockResponse = {

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -13,6 +13,29 @@ function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
 }
 
+const MOCK_TEMPLATE_API = {
+    id: 'product-launch',
+    name: 'Product launch',
+    template_type: 'project',
+    template_source: 'doist',
+    short_description: 'Ship faster',
+    long_description: 'A reusable checklist for product launches.',
+    instructions: null,
+    import_url: null,
+    view_type: 'list',
+    thumbnail_image: null,
+    thumbnail_image_dark: null,
+    cover_image: null,
+    preview_image: null,
+    template_color: null,
+    background_color: null,
+    background_color_dark: null,
+    creator: { name: 'Doist', position: 'Team', avatar: '' },
+    seo: null,
+    more_resources: [],
+    category_ids: ['productivity'],
+}
+
 describe('TodoistApi template endpoints', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -144,29 +167,6 @@ describe('TodoistApi template endpoints', () => {
     })
 
     describe('getTemplates', () => {
-        const MOCK_TEMPLATE_API = {
-            id: 'product-launch',
-            name: 'Product launch',
-            template_type: 'project',
-            template_source: 'doist',
-            short_description: 'Ship faster',
-            long_description: 'A reusable checklist for product launches.',
-            instructions: null,
-            import_url: null,
-            view_type: 'list',
-            thumbnail_image: null,
-            thumbnail_image_dark: null,
-            cover_image: null,
-            preview_image: null,
-            template_color: null,
-            background_color: null,
-            background_color_dark: null,
-            creator: { name: 'Doist', position: 'Team', avatar: '' },
-            seo: null,
-            more_resources: [],
-            category_ids: ['productivity'],
-        }
-
         test('returns validated, camelCased list with pagination metadata', async () => {
             server.use(
                 http.get(`${getSyncBaseUri()}templates/list`, () => {
@@ -264,31 +264,7 @@ describe('TodoistApi template endpoints', () => {
                 http.get(`${getSyncBaseUri()}templates/get`, ({ request }) => {
                     observedUrl = request.url
                     return HttpResponse.json(
-                        {
-                            templates: {
-                                'product-launch': {
-                                    id: 'product-launch',
-                                    name: 'Product launch',
-                                    template_type: 'project',
-                                    template_source: 'doist',
-                                    short_description: 'Ship faster',
-                                    long_description: 'desc',
-                                    instructions: null,
-                                    import_url: null,
-                                    thumbnail_image: null,
-                                    thumbnail_image_dark: null,
-                                    cover_image: null,
-                                    preview_image: null,
-                                    template_color: null,
-                                    background_color: null,
-                                    background_color_dark: null,
-                                    creator: { name: 'Doist', position: 'Team', avatar: '' },
-                                    seo: null,
-                                    more_resources: [],
-                                    category_ids: [],
-                                },
-                            },
-                        },
+                        { templates: { 'product-launch': MOCK_TEMPLATE_API } },
                         { status: 200 },
                     )
                 }),
@@ -300,13 +276,48 @@ describe('TodoistApi template endpoints', () => {
                 locale: 'en',
             })
 
-            expect(observedUrl).toContain('template_ids=product-launch%2Csprint-planning')
-            expect(observedUrl).toContain('locale=en')
+            const params = new URL(observedUrl).searchParams
+            expect(params.get('template_ids')).toBe('product-launch,sprint-planning')
+            expect(params.get('locale')).toBe('en')
             expect(Object.keys(result.templates)).toEqual(['product-launch'])
             expect(result.templates['product-launch']).toMatchObject({
                 id: 'product-launch',
                 shortDescription: 'Ship faster',
             })
+        })
+
+        test('rejects an empty templateIds array before making a request', async () => {
+            const api = getTarget()
+            await expect(api.getTemplatesByIds({ templateIds: [] })).rejects.toThrow(
+                /non-empty array/,
+            )
+        })
+
+        test('rejects more than 100 templateIds', async () => {
+            const api = getTarget()
+            const tooMany = Array.from({ length: 101 }, (_, i) => `id-${i}`)
+            await expect(api.getTemplatesByIds({ templateIds: tooMany })).rejects.toThrow(
+                /at most 100/,
+            )
+        })
+
+        test('rejects templateIds containing empty strings', async () => {
+            const api = getTarget()
+            await expect(api.getTemplatesByIds({ templateIds: ['valid', ''] })).rejects.toThrow(
+                /non-empty strings/,
+            )
+        })
+
+        test('throws when the response omits the templates field', async () => {
+            server.use(
+                http.get(`${getSyncBaseUri()}templates/get`, () => {
+                    return HttpResponse.json({}, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+            await expect(
+                api.getTemplatesByIds({ templateIds: ['product-launch'] }),
+            ).rejects.toThrow(/expected `templates` to be an object/)
         })
     })
 

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -317,7 +317,7 @@ describe('TodoistApi template endpoints', () => {
             const api = getTarget()
             await expect(
                 api.getTemplatesByIds({ templateIds: ['product-launch'] }),
-            ).rejects.toThrow(/expected `templates` to be an object/)
+            ).rejects.toThrow(/expected record/)
         })
     })
 

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -143,6 +143,12 @@ import {
     ExportTemplateUrlResponse,
     CreateProjectFromTemplateArgs,
     CreateProjectFromTemplateResponse,
+    GetTemplateCategoriesArgs,
+    GetTemplateCategoriesResponse,
+    GetTemplatesArgs,
+    GetTemplatesByIdsArgs,
+    GetTemplatesByIdsResponse,
+    GetTemplatesResponse,
     ImportTemplateIntoProjectArgs,
     ImportTemplateFromIdArgs,
     ImportTemplateResponse,
@@ -1450,6 +1456,44 @@ export class TodoistApi {
         requestId?: string,
     ): Promise<ImportTemplateResponse> {
         return this.templateClient.importTemplateFromId(args, requestId)
+    }
+
+    /**
+     * Lists templates from the Todoist gallery.
+     *
+     * The default source (`doist`) and `/categories` / `/get` for Contentful IDs require no
+     * authentication. Filtering by `user`, `workspace`, or `all` requires a token with the
+     * `data:read_write` scope.
+     *
+     * @param args - Optional filters (type, source, locale, pagination, search, category).
+     * @returns Paginated list of templates with `nextCursor` when `hasMore` is true.
+     */
+    async getTemplates(args: GetTemplatesArgs = {}): Promise<GetTemplatesResponse> {
+        return this.templateClient.getTemplates(args)
+    }
+
+    /**
+     * Lists the Contentful categories used to group gallery templates.
+     *
+     * @param args - Optional template type filter and locale.
+     * @returns The list of template categories.
+     */
+    async getTemplateCategories(
+        args: GetTemplateCategoriesArgs = {},
+    ): Promise<GetTemplateCategoriesResponse> {
+        return this.templateClient.getTemplateCategories(args)
+    }
+
+    /**
+     * Fetches one or more templates by ID. Unknown IDs are silently omitted.
+     *
+     * Authentication is required if any ID belongs to a user template.
+     *
+     * @param args - Template IDs (1..100) and optional locale.
+     * @returns A map of template ID to Template.
+     */
+    async getTemplatesByIds(args: GetTemplatesByIdsArgs): Promise<GetTemplatesByIdsResponse> {
+        return this.templateClient.getTemplatesByIds(args)
     }
 
     /* Workspace methods */

--- a/src/types/templates/index.ts
+++ b/src/types/templates/index.ts
@@ -1,1 +1,2 @@
 export * from './requests'
+export * from './types'

--- a/src/types/templates/requests.ts
+++ b/src/types/templates/requests.ts
@@ -2,6 +2,7 @@ import type { Comment } from '../comments/types'
 import type { PersonalProject, WorkspaceProject } from '../projects/types'
 import type { Section } from '../sections/types'
 import type { Task } from '../tasks/types'
+import type { Template, TemplateCategory, TemplateSourceFilter, TemplateTypeFilter } from './types'
 
 /**
  * Arguments for exporting a project as a template file.
@@ -97,4 +98,71 @@ export type ImportTemplateResponse = {
     sections: Section[]
     tasks: Task[]
     comments: Comment[]
+}
+
+/**
+ * Arguments for listing templates from the gallery.
+ * @see Undocumented; lives at `GET /api/v1/templates/list`.
+ */
+export type GetTemplatesArgs = {
+    /** Filter by template type (default `project`). */
+    templateType?: TemplateTypeFilter
+    /** Filter by template source (default `doist`). `user`/`workspace`/`all` require auth. */
+    templateSource?: TemplateSourceFilter
+    /** ISO locale used to resolve Contentful content (default `en`). */
+    locale?: string
+    /** Page size, 1..100 (default 100). */
+    limit?: number
+    /** Opaque cursor returned in `nextCursor` from a previous page. */
+    cursor?: string | null
+    /** Free-text search across template name/description. */
+    query?: string
+    /** Restrict to a single Contentful category. */
+    categoryId?: string
+}
+
+/**
+ * Response from listing templates.
+ */
+export type GetTemplatesResponse = {
+    templates: Template[]
+    count: number
+    hasMore: boolean
+    nextCursor?: string
+}
+
+/**
+ * Arguments for listing template categories.
+ * @see Undocumented; lives at `GET /api/v1/templates/categories`.
+ */
+export type GetTemplateCategoriesArgs = {
+    /** Filter by template type (default `project`). */
+    templateType?: TemplateTypeFilter
+    /** ISO locale (default `en`). */
+    locale?: string
+}
+
+/**
+ * Response from listing template categories.
+ */
+export type GetTemplateCategoriesResponse = {
+    categories: TemplateCategory[]
+}
+
+/**
+ * Arguments for fetching one or more templates by ID.
+ * @see Undocumented; lives at `GET /api/v1/templates/get`.
+ */
+export type GetTemplatesByIdsArgs = {
+    /** 1..100 template IDs. Mixing Contentful and user IDs forces auth. */
+    templateIds: string[]
+    /** ISO locale (default `en`). */
+    locale?: string
+}
+
+/**
+ * Response from fetching templates by ID. Unknown IDs are silently omitted.
+ */
+export type GetTemplatesByIdsResponse = {
+    templates: Record<string, Template>
 }

--- a/src/types/templates/requests.ts
+++ b/src/types/templates/requests.ts
@@ -2,7 +2,7 @@ import type { Comment } from '../comments/types'
 import type { PersonalProject, WorkspaceProject } from '../projects/types'
 import type { Section } from '../sections/types'
 import type { Task } from '../tasks/types'
-import type { Template, TemplateCategory, TemplateSourceFilter, TemplateTypeFilter } from './types'
+import type { TemplateSourceFilter, TemplateTypeFilter } from './types'
 
 /**
  * Arguments for exporting a project as a template file.
@@ -122,16 +122,6 @@ export type GetTemplatesArgs = {
 }
 
 /**
- * Response from listing templates.
- */
-export type GetTemplatesResponse = {
-    templates: Template[]
-    count: number
-    hasMore: boolean
-    nextCursor?: string
-}
-
-/**
  * Arguments for listing template categories.
  * @see Undocumented; lives at `GET /api/v1/templates/categories`.
  */
@@ -143,13 +133,6 @@ export type GetTemplateCategoriesArgs = {
 }
 
 /**
- * Response from listing template categories.
- */
-export type GetTemplateCategoriesResponse = {
-    categories: TemplateCategory[]
-}
-
-/**
  * Arguments for fetching one or more templates by ID.
  * @see Undocumented; lives at `GET /api/v1/templates/get`.
  */
@@ -158,11 +141,4 @@ export type GetTemplatesByIdsArgs = {
     templateIds: string[]
     /** ISO locale (default `en`). */
     locale?: string
-}
-
-/**
- * Response from fetching templates by ID. Unknown IDs are silently omitted.
- */
-export type GetTemplatesByIdsResponse = {
-    templates: Record<string, Template>
 }

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -52,7 +52,7 @@ export const TemplateSchema = z.object({
     shortDescription: z.string(),
     longDescription: z.string(),
     instructions: z.string().nullable(),
-    importUrl: z.string().nullable(),
+    importUrl: z.string().nullable().optional(),
     viewType: z.enum(PROJECT_VIEW_STYLES).optional(),
     thumbnailImage: z.string().nullable(),
     thumbnailImageDark: z.string().nullable(),

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -89,3 +89,36 @@ export const TemplateCategorySchema = z.object({
 })
 /** A Contentful-backed category used to group templates in the gallery. */
 export type TemplateCategory = z.infer<typeof TemplateCategorySchema>
+
+export const GetTemplatesResponseSchema = z.object({
+    templates: z.array(TemplateSchema),
+    count: z.number(),
+    hasMore: z.boolean(),
+    nextCursor: z.string().optional(),
+})
+/** Response from listing templates. */
+export type GetTemplatesResponse = z.infer<typeof GetTemplatesResponseSchema>
+
+export const GetTemplateCategoriesResponseSchema = z.object({
+    categories: z.array(TemplateCategorySchema),
+})
+/** Response from listing template categories. */
+export type GetTemplateCategoriesResponse = z.infer<typeof GetTemplateCategoriesResponseSchema>
+
+export const GetTemplatesByIdsResponseSchema = z
+    .object({
+        templates: z.record(z.string(), TemplateSchema),
+    })
+    .transform(({ templates }) => {
+        // The server returns a map keyed by template ID, but the HTTP client's
+        // recursive snake_case → camelCase conversion mangles those keys. Rebuild
+        // the map from each validated template's own `id` so callers get the
+        // original IDs back.
+        const out: Record<string, Template> = {}
+        for (const value of Object.values(templates)) {
+            out[value.id] = value
+        }
+        return { templates: out }
+    })
+/** Response from fetching templates by ID. Unknown IDs are silently omitted. */
+export type GetTemplatesByIdsResponse = z.infer<typeof GetTemplatesByIdsResponseSchema>

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PROJECT_VIEW_STYLES } from '../projects/types'
 
 /** Template type values returned on Template objects. */
 export const TEMPLATE_TYPE_VALUES = ['setup', 'project'] as const
@@ -19,11 +20,6 @@ export type TemplateSourceValue = (typeof TEMPLATE_SOURCE_VALUES)[number]
 export const TEMPLATE_SOURCE_FILTERS = [...TEMPLATE_SOURCE_VALUES, 'workspace', 'all'] as const
 /** Template source accepted as a query filter. */
 export type TemplateSourceFilter = (typeof TEMPLATE_SOURCE_FILTERS)[number]
-
-/** Default view types a template can suggest for an imported project. */
-export const TEMPLATE_VIEW_TYPES = ['list', 'board', 'calendar'] as const
-/** Default view type a template can suggest. */
-export type TemplateViewType = (typeof TEMPLATE_VIEW_TYPES)[number]
 
 export const TemplateCreatorSchema = z.object({
     userId: z.string().nullable().optional(),
@@ -57,7 +53,7 @@ export const TemplateSchema = z.object({
     longDescription: z.string(),
     instructions: z.string().nullable(),
     importUrl: z.string().nullable(),
-    viewType: z.enum(TEMPLATE_VIEW_TYPES).optional(),
+    viewType: z.enum(PROJECT_VIEW_STYLES).optional(),
     thumbnailImage: z.string().nullable(),
     thumbnailImageDark: z.string().nullable(),
     coverImage: z.string().nullable(),

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod'
+
+/** Template type values returned on Template objects. */
+export const TEMPLATE_TYPE_VALUES = ['setup', 'project'] as const
+/** Template type as it appears on a Template object. */
+export type TemplateTypeValue = (typeof TEMPLATE_TYPE_VALUES)[number]
+
+/** Template type values accepted as a query filter (adds `all` meta value). */
+export const TEMPLATE_TYPE_FILTERS = [...TEMPLATE_TYPE_VALUES, 'all'] as const
+/** Template type accepted as a query filter. */
+export type TemplateTypeFilter = (typeof TEMPLATE_TYPE_FILTERS)[number]
+
+/** Template source values returned on Template objects. */
+export const TEMPLATE_SOURCE_VALUES = ['doist', 'user'] as const
+/** Template source as it appears on a Template object. */
+export type TemplateSourceValue = (typeof TEMPLATE_SOURCE_VALUES)[number]
+
+/** Template source values accepted as a query filter (adds `workspace` and `all`). */
+export const TEMPLATE_SOURCE_FILTERS = [...TEMPLATE_SOURCE_VALUES, 'workspace', 'all'] as const
+/** Template source accepted as a query filter. */
+export type TemplateSourceFilter = (typeof TEMPLATE_SOURCE_FILTERS)[number]
+
+/** Default view types a template can suggest for an imported project. */
+export const TEMPLATE_VIEW_TYPES = ['list', 'board', 'calendar'] as const
+/** Default view type a template can suggest. */
+export type TemplateViewType = (typeof TEMPLATE_VIEW_TYPES)[number]
+
+export const TemplateCreatorSchema = z.object({
+    userId: z.string().nullable().optional(),
+    name: z.string(),
+    position: z.string(),
+    avatar: z.string(),
+})
+/** Information about the creator of a template (Doist or user). */
+export type TemplateCreator = z.infer<typeof TemplateCreatorSchema>
+
+export const TemplateSeoSchema = z.object({
+    title: z.string(),
+    description: z.string().nullable(),
+})
+/** SEO metadata attached to a template or category. */
+export type TemplateSeo = z.infer<typeof TemplateSeoSchema>
+
+export const TemplateResourceSchema = z.object({
+    title: z.string(),
+    url: z.string(),
+})
+/** A "more resources" link surfaced alongside a template. */
+export type TemplateResource = z.infer<typeof TemplateResourceSchema>
+
+export const TemplateSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    templateType: z.enum(TEMPLATE_TYPE_VALUES),
+    templateSource: z.enum(TEMPLATE_SOURCE_VALUES),
+    shortDescription: z.string(),
+    longDescription: z.string(),
+    instructions: z.string().nullable(),
+    importUrl: z.string().nullable(),
+    viewType: z.enum(TEMPLATE_VIEW_TYPES).optional(),
+    thumbnailImage: z.string().nullable(),
+    thumbnailImageDark: z.string().nullable(),
+    coverImage: z.string().nullable(),
+    previewImage: z.string().nullable(),
+    templateColor: z.string().nullable(),
+    backgroundColor: z.string().nullable(),
+    backgroundColorDark: z.string().nullable(),
+    creator: TemplateCreatorSchema,
+    seo: TemplateSeoSchema.nullable(),
+    moreResources: z.array(TemplateResourceSchema),
+    categoryIds: z.array(z.string()),
+    projectCount: z.number().optional(),
+    labelCount: z.number().optional(),
+    filterCount: z.number().optional(),
+    videoUrl: z.string().nullable().optional(),
+    videoPreviewImageUrl: z.string().nullable().optional(),
+    videoThumbnailImage: z.string().nullable().optional(),
+    workspaceId: z.string().nullable().optional(),
+    sharedWithWorkspaceMembers: z.boolean().optional(),
+    canEdit: z.boolean().optional(),
+})
+/**
+ * A template that can be browsed in the Todoist gallery or imported into a project.
+ * @see https://developer.todoist.com/api/v1/#tag/Templates
+ */
+export type Template = z.infer<typeof TemplateSchema>
+
+export const TemplateCategorySchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    seo: TemplateSeoSchema,
+})
+/** A Contentful-backed category used to group templates in the gallery. */
+export type TemplateCategory = z.infer<typeof TemplateCategorySchema>

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -29,6 +29,7 @@ import { WorkspaceProjectSchema, ProjectSchema } from '../types/projects/types'
 import { SectionSchema } from '../types/sections/types'
 import { type SyncResponse, SyncResponseSchema } from '../types/sync/response'
 import { TaskSchema } from '../types/tasks/types'
+import { TemplateCategorySchema, TemplateSchema } from '../types/templates/types'
 import { UiExtensionSchema } from '../types/ui-extensions/types'
 import { UserSchema, CurrentUserSchema } from '../types/users/types'
 import {
@@ -266,3 +267,9 @@ export const {
 
 export const { validate: validateUiExtension, validateArray: validateUiExtensionArray } =
     createValidator(UiExtensionSchema)
+
+export const { validate: validateTemplate, validateArray: validateTemplateArray } =
+    createValidator(TemplateSchema)
+
+export const { validate: validateTemplateCategory, validateArray: validateTemplateCategoryArray } =
+    createValidator(TemplateCategorySchema)

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -29,7 +29,13 @@ import { WorkspaceProjectSchema, ProjectSchema } from '../types/projects/types'
 import { SectionSchema } from '../types/sections/types'
 import { type SyncResponse, SyncResponseSchema } from '../types/sync/response'
 import { TaskSchema } from '../types/tasks/types'
-import { TemplateCategorySchema, TemplateSchema } from '../types/templates/types'
+import {
+    GetTemplateCategoriesResponseSchema,
+    GetTemplatesByIdsResponseSchema,
+    GetTemplatesResponseSchema,
+    TemplateCategorySchema,
+    TemplateSchema,
+} from '../types/templates/types'
 import { UiExtensionSchema } from '../types/ui-extensions/types'
 import { UserSchema, CurrentUserSchema } from '../types/users/types'
 import {
@@ -273,3 +279,15 @@ export const { validate: validateTemplate, validateArray: validateTemplateArray 
 
 export const { validate: validateTemplateCategory, validateArray: validateTemplateCategoryArray } =
     createValidator(TemplateCategorySchema)
+
+export const { validate: validateGetTemplatesResponse } = createValidator(
+    GetTemplatesResponseSchema,
+)
+
+export const { validate: validateGetTemplateCategoriesResponse } = createValidator(
+    GetTemplateCategoriesResponseSchema,
+)
+
+export const { validate: validateGetTemplatesByIdsResponse } = createValidator(
+    GetTemplatesByIdsResponseSchema,
+)


### PR DESCRIPTION
## Summary

- Adds `getTemplates`, `getTemplateCategories`, and `getTemplatesByIds` to the SDK, exposing the Todoist template gallery (Doist, user, and workspace templates). These endpoints are live but absent from the public OpenAPI spec.
- Introduces a full Zod `TemplateSchema` + `TemplateCategorySchema` with runtime validation.
- Derives query-filter unions (`TEMPLATE_TYPE_FILTERS`, `TEMPLATE_SOURCE_FILTERS`) from base response unions to keep a single source of truth — adding `'all'` / `'workspace'` only as accepted query inputs while keeping the response schema strict.
- Joins `templateIds` into a CSV (the API expects a comma-separated string param) and rebuilds the response map keyed by each template's own `id` so the auto camelCase conversion can't mangle the keys.

PR 1 of 2 — write endpoints (user-template CRUD + multipart upload) will follow in a separate PR.

## Test plan

- [x] `npm run check` (oxlint + oxfmt) passes
- [x] `npm test` — full suite, 589 tests pass
- [x] New MSW-based tests cover camelCase conversion, snake_case query param serialization, and the `/get` ID-map quirk
- [ ] Manual smoke test against the live API once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)