### PR TITLE
feat: add user-template write endpoints to TemplateClient

### DIFF
--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -228,7 +228,7 @@ export class TemplateClient extends BaseClient {
         const { data } = await request<UpdateUserTemplateResponse>({
             httpMethod: 'PUT',
             baseUri: this.syncApiBase,
-            relativePath: getUserTemplateEndpoint(encodeURIComponent(templateId)),
+            relativePath: getUserTemplateEndpoint(templateId),
             apiToken: this.authToken,
             customFetch: this.customFetch,
             payload: args,
@@ -247,7 +247,7 @@ export class TemplateClient extends BaseClient {
         const { data } = await request<DeleteUserTemplateResponse>({
             httpMethod: 'DELETE',
             baseUri: this.syncApiBase,
-            relativePath: getUserTemplateEndpoint(encodeURIComponent(templateId)),
+            relativePath: getUserTemplateEndpoint(templateId),
             apiToken: this.authToken,
             customFetch: this.customFetch,
             requestId,
@@ -277,6 +277,33 @@ export class TemplateClient extends BaseClient {
         requestId?: string,
     ): Promise<Template> {
         const { templateType, name, description, color, file, fileName, uploadedFileName } = args
+        if (file === undefined && uploadedFileName === undefined) {
+            throw new TodoistArgumentError(
+                'createUserTemplateFromFile requires either `file` or `uploadedFileName`.',
+            )
+        }
+
+        // No new upload needed — server reuses the previously uploaded CSV from S3, so
+        // skip multipart and send a regular JSON request.
+        if (file === undefined) {
+            const { data } = await request<Template>({
+                httpMethod: 'POST',
+                baseUri: this.syncApiBase,
+                relativePath: ENDPOINT_REST_TEMPLATES_USER_IMPORT,
+                apiToken: this.authToken,
+                customFetch: this.customFetch,
+                payload: {
+                    templateType,
+                    name,
+                    description,
+                    color,
+                    uploadedFileName,
+                },
+                requestId,
+            })
+            return validateTemplate(data)
+        }
+
         const additionalFields: Record<string, string> = {
             template_type: templateType,
             name,

--- a/src/clients/template-client.ts
+++ b/src/clients/template-client.ts
@@ -7,12 +7,19 @@ import {
     ENDPOINT_REST_TEMPLATES_IMPORT_FROM_ID,
     ENDPOINT_REST_TEMPLATES_LIST,
     ENDPOINT_REST_TEMPLATES_URL,
+    ENDPOINT_REST_TEMPLATES_USER,
+    ENDPOINT_REST_TEMPLATES_USER_IMPORT,
+    ENDPOINT_REST_TEMPLATES_USER_PREVIEW,
+    getUserTemplateEndpoint,
 } from '../consts/endpoints'
 import { request } from '../transport/http-client'
 import { TodoistArgumentError } from '../types/errors'
 import type {
     CreateProjectFromTemplateArgs,
     CreateProjectFromTemplateResponse,
+    CreateUserTemplateArgs,
+    CreateUserTemplateFromFileArgs,
+    DeleteUserTemplateResponse,
     ExportTemplateFileArgs,
     ExportTemplateUrlArgs,
     ExportTemplateUrlResponse,
@@ -25,17 +32,26 @@ import type {
     ImportTemplateFromIdArgs,
     ImportTemplateIntoProjectArgs,
     ImportTemplateResponse,
+    PreviewUserTemplateFromFileArgs,
+    PreviewUserTemplateFromFileResponse,
+    Template,
+    UpdateUserTemplateArgs,
+    UpdateUserTemplateResponse,
 } from '../types/templates'
 import { uploadMultipartFile } from '../utils/multipart-upload'
 import { spreadIfDefined } from '../utils/request-helpers'
 import {
     validateCommentArray,
+    validateDeleteUserTemplateResponse,
     validateGetTemplateCategoriesResponse,
     validateGetTemplatesByIdsResponse,
     validateGetTemplatesResponse,
+    validatePreviewUserTemplateFromFileResponse,
     validateProjectArray,
     validateSectionArray,
     validateTaskArray,
+    validateTemplate,
+    validateUpdateUserTemplateResponse,
 } from '../utils/validators'
 import { BaseClient } from './base-client'
 
@@ -186,6 +202,101 @@ export class TemplateClient extends BaseClient {
             },
         })
         return validateGetTemplatesByIdsResponse(data)
+    }
+
+    async createUserTemplate(args: CreateUserTemplateArgs, requestId?: string): Promise<Template> {
+        const { data } = await request<Template>({
+            httpMethod: 'POST',
+            baseUri: this.syncApiBase,
+            relativePath: ENDPOINT_REST_TEMPLATES_USER,
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+            requestId,
+        })
+        return validateTemplate(data)
+    }
+
+    async updateUserTemplate(
+        templateId: string,
+        args: UpdateUserTemplateArgs = {},
+        requestId?: string,
+    ): Promise<UpdateUserTemplateResponse> {
+        if (!templateId) {
+            throw new TodoistArgumentError('templateId is required.')
+        }
+        const { data } = await request<UpdateUserTemplateResponse>({
+            httpMethod: 'PUT',
+            baseUri: this.syncApiBase,
+            relativePath: getUserTemplateEndpoint(encodeURIComponent(templateId)),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            payload: args,
+            requestId,
+        })
+        return validateUpdateUserTemplateResponse(data)
+    }
+
+    async deleteUserTemplate(
+        templateId: string,
+        requestId?: string,
+    ): Promise<DeleteUserTemplateResponse> {
+        if (!templateId) {
+            throw new TodoistArgumentError('templateId is required.')
+        }
+        const { data } = await request<DeleteUserTemplateResponse>({
+            httpMethod: 'DELETE',
+            baseUri: this.syncApiBase,
+            relativePath: getUserTemplateEndpoint(encodeURIComponent(templateId)),
+            apiToken: this.authToken,
+            customFetch: this.customFetch,
+            requestId,
+        })
+        return validateDeleteUserTemplateResponse(data)
+    }
+
+    async previewUserTemplateFromFile(
+        args: PreviewUserTemplateFromFileArgs,
+        requestId?: string,
+    ): Promise<PreviewUserTemplateFromFileResponse> {
+        const data = await uploadMultipartFile({
+            baseUrl: this.syncApiBase,
+            authToken: this.authToken,
+            endpoint: ENDPOINT_REST_TEMPLATES_USER_PREVIEW,
+            file: args.file,
+            fileName: args.fileName,
+            additionalFields: {},
+            customFetch: this.customFetch,
+            requestId,
+        })
+        return validatePreviewUserTemplateFromFileResponse(data)
+    }
+
+    async createUserTemplateFromFile(
+        args: CreateUserTemplateFromFileArgs,
+        requestId?: string,
+    ): Promise<Template> {
+        const { templateType, name, description, color, file, fileName, uploadedFileName } = args
+        const additionalFields: Record<string, string> = {
+            template_type: templateType,
+            name,
+            description,
+            color: String(color),
+        }
+        if (uploadedFileName !== undefined) {
+            additionalFields.uploaded_file_name = uploadedFileName
+        }
+        const data = await uploadMultipartFile({
+            baseUrl: this.syncApiBase,
+            authToken: this.authToken,
+            endpoint: ENDPOINT_REST_TEMPLATES_USER_IMPORT,
+            file,
+            fileName,
+            additionalFields,
+            customFetch: this.customFetch,
+            requestId,
+        })
+        return validateTemplate(data)
     }
 
     private validateTemplateResponse(data: Record<string, unknown>) {

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -71,6 +71,12 @@ export const ENDPOINT_REST_TEMPLATES_IMPORT_FROM_ID =
 export const ENDPOINT_REST_TEMPLATES_LIST = 'templates/list'
 export const ENDPOINT_REST_TEMPLATES_CATEGORIES = 'templates/categories'
 export const ENDPOINT_REST_TEMPLATES_GET = 'templates/get'
+export const ENDPOINT_REST_TEMPLATES_USER = 'templates/user'
+export const ENDPOINT_REST_TEMPLATES_USER_PREVIEW = 'templates/user/preview_from_file'
+export const ENDPOINT_REST_TEMPLATES_USER_IMPORT = 'templates/user/import'
+export function getUserTemplateEndpoint(templateId: string): string {
+    return `${ENDPOINT_REST_TEMPLATES_USER}/${templateId}`
+}
 
 export const ENDPOINT_REST_ACCESS_TOKENS_MIGRATE = 'access_tokens/migrate_personal_token'
 export const ENDPOINT_REST_BACKUPS = 'backups'

--- a/src/consts/endpoints.ts
+++ b/src/consts/endpoints.ts
@@ -75,7 +75,7 @@ export const ENDPOINT_REST_TEMPLATES_USER = 'templates/user'
 export const ENDPOINT_REST_TEMPLATES_USER_PREVIEW = 'templates/user/preview_from_file'
 export const ENDPOINT_REST_TEMPLATES_USER_IMPORT = 'templates/user/import'
 export function getUserTemplateEndpoint(templateId: string): string {
-    return `${ENDPOINT_REST_TEMPLATES_USER}/${templateId}`
+    return `${ENDPOINT_REST_TEMPLATES_USER}/${encodeURIComponent(templateId)}`
 }
 
 export const ENDPOINT_REST_ACCESS_TOKENS_MIGRATE = 'access_tokens/migrate_personal_token'

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -507,15 +507,27 @@ describe('TodoistApi template endpoints', () => {
     })
 
     describe('previewUserTemplateFromFile', () => {
-        test('uploads file and returns validated preview', async () => {
+        test('uploads file, renames items→tasks, concats notes+projectNotes→comments', async () => {
+            const taskNote = {
+                id: 'note_1',
+                content: 'Task note',
+                postedAt: '2026-05-15T00:00:00Z',
+                postedUid: 'u1',
+                itemId: 'task_1',
+                fileAttachment: null,
+                uidsToNotify: null,
+                isDeleted: false,
+                reactions: null,
+            }
+            const projectNote = { ...taskNote, id: 'note_2', itemId: undefined, projectId: 'p1' }
             mockedUploadMultipartFile.mockResolvedValue({
                 uploadedFileName: 'template.csv',
                 templateType: 'project',
                 projects: [],
                 sections: [DEFAULT_SECTION],
                 items: [DEFAULT_TASK],
-                notes: [],
-                projectNotes: [],
+                notes: [taskNote],
+                projectNotes: [projectNote],
             })
             const api = getTarget()
 
@@ -531,8 +543,10 @@ describe('TodoistApi template endpoints', () => {
                 }),
             )
             expect(result.uploadedFileName).toBe('template.csv')
-            expect(result.items).toHaveLength(1)
+            expect(result.tasks).toHaveLength(1)
             expect(result.sections).toHaveLength(1)
+            expect(result.comments).toHaveLength(2)
+            expect(result.comments.map((c) => c.id)).toEqual(['note_1', 'note_2'])
         })
     })
 

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -3,6 +3,7 @@ import { TodoistApi } from '.'
 import { getSyncBaseUri } from './consts/endpoints'
 import { server, http, HttpResponse } from './test-utils/msw-setup'
 import { DEFAULT_AUTH_TOKEN, DEFAULT_SECTION, DEFAULT_TASK } from './test-utils/test-defaults'
+import { camelCaseKeys } from './utils/case-conversion'
 import { uploadMultipartFile } from './utils/multipart-upload'
 
 // Mock the multipart upload helper
@@ -37,28 +38,11 @@ const MOCK_TEMPLATE_API = {
 }
 
 // Pre-camelCased version for `uploadMultipartFile` mocks (the real helper performs the
-// snake_case → camelCase conversion before resolving).
+// snake_case → camelCase conversion before resolving). Derived from `MOCK_TEMPLATE_API` so
+// schema changes only need updating in one place.
 const MOCK_TEMPLATE_CAMEL = {
-    id: 'product-launch',
-    name: 'Product launch',
-    templateType: 'project',
+    ...(camelCaseKeys(MOCK_TEMPLATE_API) as Record<string, unknown>),
     templateSource: 'user',
-    shortDescription: 'Ship faster',
-    longDescription: 'A reusable checklist for product launches.',
-    instructions: null,
-    importUrl: null,
-    viewType: 'list',
-    thumbnailImage: null,
-    thumbnailImageDark: null,
-    coverImage: null,
-    previewImage: null,
-    templateColor: null,
-    backgroundColor: null,
-    backgroundColorDark: null,
-    creator: { name: 'Doist', position: 'Team', avatar: '' },
-    seo: null,
-    moreResources: [],
-    categoryIds: ['productivity'],
 }
 
 describe('TodoistApi template endpoints', () => {
@@ -504,6 +488,24 @@ describe('TodoistApi template endpoints', () => {
             const api = getTarget()
             await expect(api.deleteUserTemplate('')).rejects.toThrow(/templateId is required/)
         })
+
+        test('URL-encodes templateId path segment', async () => {
+            let observedUrl = ''
+            server.use(
+                http.delete(
+                    `${getSyncBaseUri()}templates/user/user%2Ftemplate%2F1`,
+                    ({ request }) => {
+                        observedUrl = request.url
+                        return HttpResponse.json({ status: 'ok' }, { status: 200 })
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            await api.deleteUserTemplate('user/template/1')
+
+            expect(observedUrl).toContain('templates/user/user%2Ftemplate%2F1')
+        })
     })
 
     describe('previewUserTemplateFromFile', () => {
@@ -578,7 +580,7 @@ describe('TodoistApi template endpoints', () => {
             expect(result).toMatchObject({ id: 'product-launch', templateSource: 'user' })
         })
 
-        test('passes uploadedFileName through when supplied', async () => {
+        test('passes uploadedFileName through when supplied alongside a file', async () => {
             mockedUploadMultipartFile.mockResolvedValue(MOCK_TEMPLATE_CAMEL)
             const api = getTarget()
 
@@ -599,6 +601,50 @@ describe('TodoistApi template endpoints', () => {
                     }),
                 }),
             )
+        })
+
+        test('sends a JSON POST (no multipart upload) when only uploadedFileName is provided', async () => {
+            let observedBody: Record<string, unknown> | undefined
+            server.use(
+                http.post(`${getSyncBaseUri()}templates/user/import`, async ({ request }) => {
+                    observedBody = (await request.json()) as Record<string, unknown>
+                    return HttpResponse.json(
+                        { ...MOCK_TEMPLATE_API, template_source: 'user' },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.createUserTemplateFromFile({
+                templateType: 'project',
+                name: 'From cached',
+                description: 'desc',
+                color: 'lime_green',
+                uploadedFileName: 'prev-upload.csv',
+            })
+
+            expect(mockedUploadMultipartFile).not.toHaveBeenCalled()
+            expect(observedBody).toEqual({
+                template_type: 'project',
+                name: 'From cached',
+                description: 'desc',
+                color: 'lime_green',
+                uploaded_file_name: 'prev-upload.csv',
+            })
+            expect(result.templateSource).toBe('user')
+        })
+
+        test('rejects when neither file nor uploadedFileName is provided', async () => {
+            const api = getTarget()
+            await expect(
+                api.createUserTemplateFromFile({
+                    templateType: 'project',
+                    name: 'x',
+                    description: 'y',
+                    color: 'lime_green',
+                }),
+            ).rejects.toThrow(/requires either `file` or `uploadedFileName`/)
         })
     })
 })

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -36,6 +36,31 @@ const MOCK_TEMPLATE_API = {
     category_ids: ['productivity'],
 }
 
+// Pre-camelCased version for `uploadMultipartFile` mocks (the real helper performs the
+// snake_case → camelCase conversion before resolving).
+const MOCK_TEMPLATE_CAMEL = {
+    id: 'product-launch',
+    name: 'Product launch',
+    templateType: 'project',
+    templateSource: 'user',
+    shortDescription: 'Ship faster',
+    longDescription: 'A reusable checklist for product launches.',
+    instructions: null,
+    importUrl: null,
+    viewType: 'list',
+    thumbnailImage: null,
+    thumbnailImageDark: null,
+    coverImage: null,
+    previewImage: null,
+    templateColor: null,
+    backgroundColor: null,
+    backgroundColorDark: null,
+    creator: { name: 'Doist', position: 'Team', avatar: '' },
+    seo: null,
+    moreResources: [],
+    categoryIds: ['productivity'],
+}
+
 describe('TodoistApi template endpoints', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -351,6 +376,221 @@ describe('TodoistApi template endpoints', () => {
             expect(result.templateType).toBe('project')
             expect(result.tasks).toEqual([])
             expect(result.sections).toEqual([])
+        })
+    })
+
+    describe('createUserTemplate', () => {
+        test('POSTs JSON payload and returns validated template', async () => {
+            let observedBody: Record<string, unknown> | undefined
+            server.use(
+                http.post(`${getSyncBaseUri()}templates/user`, async ({ request }) => {
+                    observedBody = (await request.json()) as Record<string, unknown>
+                    return HttpResponse.json(
+                        { ...MOCK_TEMPLATE_API, template_source: 'user' },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const result = await api.createUserTemplate({
+                templateType: 'project',
+                name: 'My template',
+                description: 'desc',
+                projectId: 'proj_1',
+                color: 'lime_green',
+                forWorkspace: true,
+            })
+
+            expect(observedBody).toEqual({
+                template_type: 'project',
+                name: 'My template',
+                description: 'desc',
+                project_id: 'proj_1',
+                color: 'lime_green',
+                for_workspace: true,
+            })
+            expect(result).toMatchObject({
+                id: 'product-launch',
+                templateSource: 'user',
+                name: 'Product launch',
+            })
+        })
+    })
+
+    describe('updateUserTemplate', () => {
+        test('PUTs only the supplied fields and returns template + status', async () => {
+            let observedUrl = ''
+            let observedBody: Record<string, unknown> | undefined
+            server.use(
+                http.put(
+                    `${getSyncBaseUri()}templates/user/user_template_42`,
+                    async ({ request }) => {
+                        observedUrl = request.url
+                        observedBody = (await request.json()) as Record<string, unknown>
+                        return HttpResponse.json(
+                            {
+                                status: 'ok',
+                                ...MOCK_TEMPLATE_API,
+                                template_source: 'user',
+                                name: 'Renamed',
+                            },
+                            { status: 200 },
+                        )
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            const result = await api.updateUserTemplate('user_template_42', {
+                name: 'Renamed',
+                sharedWithWorkspaceMembers: true,
+            })
+
+            expect(observedUrl).toContain('templates/user/user_template_42')
+            expect(observedBody).toEqual({
+                name: 'Renamed',
+                shared_with_workspace_members: true,
+            })
+            expect(result.status).toBe('ok')
+            expect(result.name).toBe('Renamed')
+            expect(result.templateSource).toBe('user')
+        })
+
+        test('rejects an empty templateId before making a request', async () => {
+            const api = getTarget()
+            await expect(api.updateUserTemplate('', { name: 'x' })).rejects.toThrow(
+                /templateId is required/,
+            )
+        })
+
+        test('URL-encodes templateId path segment', async () => {
+            let observedUrl = ''
+            server.use(
+                http.put(
+                    `${getSyncBaseUri()}templates/user/user%2Ftemplate%2F1`,
+                    ({ request }) => {
+                        observedUrl = request.url
+                        return HttpResponse.json(
+                            { status: 'ok', ...MOCK_TEMPLATE_API, template_source: 'user' },
+                            { status: 200 },
+                        )
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            await api.updateUserTemplate('user/template/1', { name: 'x' })
+
+            expect(observedUrl).toContain('templates/user/user%2Ftemplate%2F1')
+        })
+    })
+
+    describe('deleteUserTemplate', () => {
+        test('DELETEs and returns status', async () => {
+            let observedMethod = ''
+            server.use(
+                http.delete(
+                    `${getSyncBaseUri()}templates/user/user_template_42`,
+                    ({ request }) => {
+                        observedMethod = request.method
+                        return HttpResponse.json({ status: 'ok' }, { status: 200 })
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            const result = await api.deleteUserTemplate('user_template_42')
+
+            expect(observedMethod).toBe('DELETE')
+            expect(result).toEqual({ status: 'ok' })
+        })
+
+        test('rejects an empty templateId before making a request', async () => {
+            const api = getTarget()
+            await expect(api.deleteUserTemplate('')).rejects.toThrow(/templateId is required/)
+        })
+    })
+
+    describe('previewUserTemplateFromFile', () => {
+        test('uploads file and returns validated preview', async () => {
+            mockedUploadMultipartFile.mockResolvedValue({
+                uploadedFileName: 'template.csv',
+                templateType: 'project',
+                projects: [],
+                sections: [DEFAULT_SECTION],
+                items: [DEFAULT_TASK],
+                notes: [],
+                projectNotes: [],
+            })
+            const api = getTarget()
+
+            const result = await api.previewUserTemplateFromFile({
+                file: Buffer.from('content'),
+                fileName: 'template.csv',
+            })
+
+            expect(mockedUploadMultipartFile).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    endpoint: 'templates/user/preview_from_file',
+                    additionalFields: {},
+                }),
+            )
+            expect(result.uploadedFileName).toBe('template.csv')
+            expect(result.items).toHaveLength(1)
+            expect(result.sections).toHaveLength(1)
+        })
+    })
+
+    describe('createUserTemplateFromFile', () => {
+        test('uploads file with template metadata and returns validated template', async () => {
+            mockedUploadMultipartFile.mockResolvedValue(MOCK_TEMPLATE_CAMEL)
+            const api = getTarget()
+
+            const result = await api.createUserTemplateFromFile({
+                templateType: 'project',
+                name: 'From file',
+                description: 'desc',
+                color: 30,
+                file: Buffer.from('content'),
+                fileName: 'template.csv',
+            })
+
+            expect(mockedUploadMultipartFile).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    endpoint: 'templates/user/import',
+                    additionalFields: {
+                        template_type: 'project',
+                        name: 'From file',
+                        description: 'desc',
+                        color: '30',
+                    },
+                }),
+            )
+            expect(result).toMatchObject({ id: 'product-launch', templateSource: 'user' })
+        })
+
+        test('passes uploadedFileName through when supplied', async () => {
+            mockedUploadMultipartFile.mockResolvedValue(MOCK_TEMPLATE_CAMEL)
+            const api = getTarget()
+
+            await api.createUserTemplateFromFile({
+                templateType: 'project',
+                name: 'From file',
+                description: 'desc',
+                color: 'lime_green',
+                file: Buffer.from('content'),
+                fileName: 'template.csv',
+                uploadedFileName: 'prev-upload.csv',
+            })
+
+            expect(mockedUploadMultipartFile).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    additionalFields: expect.objectContaining({
+                        uploaded_file_name: 'prev-upload.csv',
+                    }),
+                }),
+            )
         })
     })
 })

--- a/src/todoist-api.templates.test.ts
+++ b/src/todoist-api.templates.test.ts
@@ -467,16 +467,13 @@ describe('TodoistApi template endpoints', () => {
         test('URL-encodes templateId path segment', async () => {
             let observedUrl = ''
             server.use(
-                http.put(
-                    `${getSyncBaseUri()}templates/user/user%2Ftemplate%2F1`,
-                    ({ request }) => {
-                        observedUrl = request.url
-                        return HttpResponse.json(
-                            { status: 'ok', ...MOCK_TEMPLATE_API, template_source: 'user' },
-                            { status: 200 },
-                        )
-                    },
-                ),
+                http.put(`${getSyncBaseUri()}templates/user/user%2Ftemplate%2F1`, ({ request }) => {
+                    observedUrl = request.url
+                    return HttpResponse.json(
+                        { status: 'ok', ...MOCK_TEMPLATE_API, template_source: 'user' },
+                        { status: 200 },
+                    )
+                }),
             )
             const api = getTarget()
 
@@ -490,13 +487,10 @@ describe('TodoistApi template endpoints', () => {
         test('DELETEs and returns status', async () => {
             let observedMethod = ''
             server.use(
-                http.delete(
-                    `${getSyncBaseUri()}templates/user/user_template_42`,
-                    ({ request }) => {
-                        observedMethod = request.method
-                        return HttpResponse.json({ status: 'ok' }, { status: 200 })
-                    },
-                ),
+                http.delete(`${getSyncBaseUri()}templates/user/user_template_42`, ({ request }) => {
+                    observedMethod = request.method
+                    return HttpResponse.json({ status: 'ok' }, { status: 200 })
+                }),
             )
             const api = getTarget()
 

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -143,6 +143,9 @@ import {
     ExportTemplateUrlResponse,
     CreateProjectFromTemplateArgs,
     CreateProjectFromTemplateResponse,
+    CreateUserTemplateArgs,
+    CreateUserTemplateFromFileArgs,
+    DeleteUserTemplateResponse,
     GetTemplateCategoriesArgs,
     GetTemplateCategoriesResponse,
     GetTemplatesArgs,
@@ -152,6 +155,11 @@ import {
     ImportTemplateIntoProjectArgs,
     ImportTemplateFromIdArgs,
     ImportTemplateResponse,
+    PreviewUserTemplateFromFileArgs,
+    PreviewUserTemplateFromFileResponse,
+    Template,
+    UpdateUserTemplateArgs,
+    UpdateUserTemplateResponse,
 } from './types/templates'
 import type {
     AddUiExtensionArgs,
@@ -1494,6 +1502,83 @@ export class TodoistApi {
      */
     async getTemplatesByIds(args: GetTemplatesByIdsArgs): Promise<GetTemplatesByIdsResponse> {
         return this.templateClient.getTemplatesByIds(args)
+    }
+
+    /**
+     * Creates a new user template from an existing project.
+     *
+     * Requires an OAuth token with the `data:read_write` scope.
+     *
+     * @param args - Template metadata + source `projectId` + Todoist color.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns The newly created template.
+     */
+    async createUserTemplate(args: CreateUserTemplateArgs, requestId?: string): Promise<Template> {
+        return this.templateClient.createUserTemplate(args, requestId)
+    }
+
+    /**
+     * Updates an existing user template. Only supplied fields are changed.
+     *
+     * @param templateId - ID of the user template to update.
+     * @param args - Fields to overwrite. Omit a field to leave it unchanged.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns The updated template plus a `status: 'ok'` flag.
+     */
+    async updateUserTemplate(
+        templateId: string,
+        args?: UpdateUserTemplateArgs,
+        requestId?: string,
+    ): Promise<UpdateUserTemplateResponse> {
+        return this.templateClient.updateUserTemplate(templateId, args, requestId)
+    }
+
+    /**
+     * Deletes a user template.
+     *
+     * @param templateId - ID of the user template to delete.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns `{ status: 'ok' }` on success.
+     */
+    async deleteUserTemplate(
+        templateId: string,
+        requestId?: string,
+    ): Promise<DeleteUserTemplateResponse> {
+        return this.templateClient.deleteUserTemplate(templateId, requestId)
+    }
+
+    /**
+     * Previews an uploaded template CSV before creating a user template from it.
+     *
+     * The returned `uploadedFileName` can be passed to {@link createUserTemplateFromFile}
+     * via its `uploadedFileName` field so the file does not need to be re-uploaded.
+     *
+     * @param args - Template CSV file and optional file name.
+     * @param requestId - Optional custom identifier for the request.
+     * @returns The parsed preview plus the server-side uploaded file name.
+     */
+    async previewUserTemplateFromFile(
+        args: PreviewUserTemplateFromFileArgs,
+        requestId?: string,
+    ): Promise<PreviewUserTemplateFromFileResponse> {
+        return this.templateClient.previewUserTemplateFromFile(args, requestId)
+    }
+
+    /**
+     * Creates a new user template by uploading a template CSV file.
+     *
+     * If the file was already uploaded via {@link previewUserTemplateFromFile}, pass
+     * its `uploadedFileName` to skip re-uploading.
+     *
+     * @param args - Template metadata + the CSV file (or previously uploaded file name).
+     * @param requestId - Optional custom identifier for the request.
+     * @returns The newly created template.
+     */
+    async createUserTemplateFromFile(
+        args: CreateUserTemplateFromFileArgs,
+        requestId?: string,
+    ): Promise<Template> {
+        return this.templateClient.createUserTemplateFromFile(args, requestId)
     }
 
     /* Workspace methods */

--- a/src/types/templates/requests.ts
+++ b/src/types/templates/requests.ts
@@ -1,8 +1,13 @@
+import type { ColorKey } from '../../utils/colors'
 import type { Comment } from '../comments/types'
 import type { PersonalProject, WorkspaceProject } from '../projects/types'
 import type { Section } from '../sections/types'
 import type { Task } from '../tasks/types'
+import type { UploadFileArgs } from '../uploads/requests'
 import type { TemplateSourceFilter, TemplateTypeFilter } from './types'
+
+/** Shared file-upload surface for endpoints that accept a template CSV. */
+type TemplateFileUpload = Pick<UploadFileArgs, 'file' | 'fileName'>
 
 /**
  * Arguments for exporting a project as a template file.
@@ -38,13 +43,9 @@ export type ExportTemplateUrlResponse = {
  * Arguments for creating a project from a template file.
  * @see https://developer.todoist.com/api/v1/#tag/Templates/operation/create_project_from_file_api_v1_templates_create_project_from_file_post
  */
-export type CreateProjectFromTemplateArgs = {
+export type CreateProjectFromTemplateArgs = TemplateFileUpload & {
     /** Name for the new project. */
     name: string
-    /** The template file content. */
-    file: Buffer | NodeJS.ReadableStream | string | Blob
-    /** Optional file name (required for Buffer/Stream). */
-    fileName?: string
     /** Optional workspace ID. */
     workspaceId?: string | null
 }
@@ -66,13 +67,9 @@ export type CreateProjectFromTemplateResponse = {
  * Arguments for importing a template file into an existing project.
  * @see https://developer.todoist.com/api/v1/#tag/Templates/operation/import_into_project_from_file_api_v1_templates_import_into_project_from_file_post
  */
-export type ImportTemplateIntoProjectArgs = {
+export type ImportTemplateIntoProjectArgs = TemplateFileUpload & {
     /** The project ID to import into. */
     projectId: string
-    /** The template file content. */
-    file: Buffer | NodeJS.ReadableStream | string | Blob
-    /** Optional file name (required for Buffer/Stream). */
-    fileName?: string
 }
 
 /**
@@ -156,8 +153,8 @@ export type CreateUserTemplateArgs = {
     description: string
     /** ID of the project to capture as a template. */
     projectId: string
-    /** Todoist color name or numeric ID. */
-    color: string | number
+    /** Todoist color key (e.g. `lime_green`) or its numeric ID. */
+    color: ColorKey | number
     /** If true, save into the workspace gallery instead of the user's personal gallery. */
     forWorkspace?: boolean
 }
@@ -173,8 +170,8 @@ export type UpdateUserTemplateArgs = {
     description?: string
     /** Replace the source project used to build the template. */
     projectId?: string
-    /** New Todoist color. */
-    color?: string | number
+    /** New Todoist color key or numeric ID. */
+    color?: ColorKey | number
     /** Move the template into a specific workspace gallery. */
     workspaceId?: string | null
     /** Toggle workspace-member visibility. */
@@ -185,33 +182,29 @@ export type UpdateUserTemplateArgs = {
  * Arguments for previewing a CSV template file before importing it as a user template.
  * @see Undocumented; lives at `POST /api/v1/templates/user/preview_from_file`.
  */
-export type PreviewUserTemplateFromFileArgs = {
-    /** Template CSV file contents. */
-    file: Buffer | NodeJS.ReadableStream | string | Blob
-    /** Optional file name (required for Buffer/Stream uploads). */
-    fileName?: string
-}
+export type PreviewUserTemplateFromFileArgs = TemplateFileUpload
 
 /**
  * Arguments for creating a new user template by uploading a CSV file.
+ *
+ * Provide either `file` (the SDK uploads it) or `uploadedFileName` (server reuses a
+ * previously uploaded file from {@link PreviewUserTemplateFromFileArgs}). One of the
+ * two is required.
+ *
  * @see Undocumented; lives at `POST /api/v1/templates/user/import`.
  */
-export type CreateUserTemplateFromFileArgs = {
+export type CreateUserTemplateFromFileArgs = Partial<TemplateFileUpload> & {
     /** Template type. Only `project` is currently supported by the API. */
     templateType: 'project'
     /** Display name for the template (max 255 chars). */
     name: string
     /** Long description (max 1000 chars). */
     description: string
-    /** Todoist color name or numeric ID. */
-    color: string | number
-    /** Template CSV file contents. */
-    file: Buffer | NodeJS.ReadableStream | string | Blob
-    /** Optional file name (required for Buffer/Stream uploads). */
-    fileName?: string
+    /** Todoist color key (e.g. `lime_green`) or its numeric ID. */
+    color: ColorKey | number
     /**
      * If the file has already been uploaded via `previewUserTemplateFromFile`, pass the
-     * returned `uploadedFileName` to skip re-uploading.
+     * returned `uploadedFileName` to skip re-uploading. Required when `file` is omitted.
      */
     uploadedFileName?: string
 }

--- a/src/types/templates/requests.ts
+++ b/src/types/templates/requests.ts
@@ -142,3 +142,76 @@ export type GetTemplatesByIdsArgs = {
     /** ISO locale (default `en`). */
     locale?: string
 }
+
+/**
+ * Arguments for creating a new user template from an existing project.
+ * @see Undocumented; lives at `POST /api/v1/templates/user`.
+ */
+export type CreateUserTemplateArgs = {
+    /** Template type. Only `project` is currently supported by the API. */
+    templateType: 'project'
+    /** Display name for the template (max 255 chars). */
+    name: string
+    /** Long description (max 1000 chars). */
+    description: string
+    /** ID of the project to capture as a template. */
+    projectId: string
+    /** Todoist color name or numeric ID. */
+    color: string | number
+    /** If true, save into the workspace gallery instead of the user's personal gallery. */
+    forWorkspace?: boolean
+}
+
+/**
+ * Arguments for updating an existing user template. Only supplied fields are changed.
+ * @see Undocumented; lives at `PUT /api/v1/templates/user/{template_id}`.
+ */
+export type UpdateUserTemplateArgs = {
+    /** New display name (max 255 chars). */
+    name?: string
+    /** New long description (max 1000 chars). */
+    description?: string
+    /** Replace the source project used to build the template. */
+    projectId?: string
+    /** New Todoist color. */
+    color?: string | number
+    /** Move the template into a specific workspace gallery. */
+    workspaceId?: string | null
+    /** Toggle workspace-member visibility. */
+    sharedWithWorkspaceMembers?: boolean
+}
+
+/**
+ * Arguments for previewing a CSV template file before importing it as a user template.
+ * @see Undocumented; lives at `POST /api/v1/templates/user/preview_from_file`.
+ */
+export type PreviewUserTemplateFromFileArgs = {
+    /** Template CSV file contents. */
+    file: Buffer | NodeJS.ReadableStream | string | Blob
+    /** Optional file name (required for Buffer/Stream uploads). */
+    fileName?: string
+}
+
+/**
+ * Arguments for creating a new user template by uploading a CSV file.
+ * @see Undocumented; lives at `POST /api/v1/templates/user/import`.
+ */
+export type CreateUserTemplateFromFileArgs = {
+    /** Template type. Only `project` is currently supported by the API. */
+    templateType: 'project'
+    /** Display name for the template (max 255 chars). */
+    name: string
+    /** Long description (max 1000 chars). */
+    description: string
+    /** Todoist color name or numeric ID. */
+    color: string | number
+    /** Template CSV file contents. */
+    file: Buffer | NodeJS.ReadableStream | string | Blob
+    /** Optional file name (required for Buffer/Stream uploads). */
+    fileName?: string
+    /**
+     * If the file has already been uploaded via `previewUserTemplateFromFile`, pass the
+     * returned `uploadedFileName` to skip re-uploading.
+     */
+    uploadedFileName?: string
+}

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -138,15 +138,23 @@ export const DeleteUserTemplateResponseSchema = z.object({
 /** Response from deleting a user template. */
 export type DeleteUserTemplateResponse = z.infer<typeof DeleteUserTemplateResponseSchema>
 
-export const PreviewUserTemplateFromFileResponseSchema = z.object({
-    uploadedFileName: z.string(),
-    templateType: z.string(),
-    projects: z.array(ProjectSchema),
-    sections: z.array(SectionSchema),
-    items: z.array(TaskSchema),
-    notes: z.array(CommentSchema),
-    projectNotes: z.array(CommentSchema),
-})
+export const PreviewUserTemplateFromFileResponseSchema = z
+    .object({
+        uploadedFileName: z.string(),
+        templateType: z.string(),
+        projects: z.array(ProjectSchema),
+        sections: z.array(SectionSchema),
+        items: z.array(TaskSchema),
+        notes: z.array(CommentSchema),
+        projectNotes: z.array(CommentSchema),
+    })
+    .transform(({ items, notes, projectNotes, ...rest }) => ({
+        ...rest,
+        // Match the rest of the SDK: server `items` → `tasks`; project-level notes and
+        // task notes are both Comments here, so concatenate into a single `comments` array.
+        tasks: items,
+        comments: [...notes, ...projectNotes],
+    }))
 /**
  * Response from previewing a user template from an uploaded CSV file.
  * The `uploadedFileName` can be passed to the import endpoint to skip re-uploading.

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -141,7 +141,7 @@ export type DeleteUserTemplateResponse = z.infer<typeof DeleteUserTemplateRespon
 export const PreviewUserTemplateFromFileResponseSchema = z
     .object({
         uploadedFileName: z.string(),
-        templateType: z.string(),
+        templateType: z.enum(TEMPLATE_TYPE_VALUES),
         projects: z.array(ProjectSchema),
         sections: z.array(SectionSchema),
         items: z.array(TaskSchema),

--- a/src/types/templates/types.ts
+++ b/src/types/templates/types.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
-import { PROJECT_VIEW_STYLES } from '../projects/types'
+import { CommentSchema } from '../comments/types'
+import { ProjectSchema, PROJECT_VIEW_STYLES } from '../projects/types'
+import { SectionSchema } from '../sections/types'
+import { TaskSchema } from '../tasks/types'
 
 /** Template type values returned on Template objects. */
 export const TEMPLATE_TYPE_VALUES = ['setup', 'project'] as const
@@ -122,3 +125,32 @@ export const GetTemplatesByIdsResponseSchema = z
     })
 /** Response from fetching templates by ID. Unknown IDs are silently omitted. */
 export type GetTemplatesByIdsResponse = z.infer<typeof GetTemplatesByIdsResponseSchema>
+
+export const UpdateUserTemplateResponseSchema = TemplateSchema.extend({
+    status: z.literal('ok'),
+})
+/** Response from updating a user template. */
+export type UpdateUserTemplateResponse = z.infer<typeof UpdateUserTemplateResponseSchema>
+
+export const DeleteUserTemplateResponseSchema = z.object({
+    status: z.literal('ok'),
+})
+/** Response from deleting a user template. */
+export type DeleteUserTemplateResponse = z.infer<typeof DeleteUserTemplateResponseSchema>
+
+export const PreviewUserTemplateFromFileResponseSchema = z.object({
+    uploadedFileName: z.string(),
+    templateType: z.string(),
+    projects: z.array(ProjectSchema),
+    sections: z.array(SectionSchema),
+    items: z.array(TaskSchema),
+    notes: z.array(CommentSchema),
+    projectNotes: z.array(CommentSchema),
+})
+/**
+ * Response from previewing a user template from an uploaded CSV file.
+ * The `uploadedFileName` can be passed to the import endpoint to skip re-uploading.
+ */
+export type PreviewUserTemplateFromFileResponse = z.infer<
+    typeof PreviewUserTemplateFromFileResponseSchema
+>

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -30,11 +30,14 @@ import { SectionSchema } from '../types/sections/types'
 import { type SyncResponse, SyncResponseSchema } from '../types/sync/response'
 import { TaskSchema } from '../types/tasks/types'
 import {
+    DeleteUserTemplateResponseSchema,
     GetTemplateCategoriesResponseSchema,
     GetTemplatesByIdsResponseSchema,
     GetTemplatesResponseSchema,
+    PreviewUserTemplateFromFileResponseSchema,
     TemplateCategorySchema,
     TemplateSchema,
+    UpdateUserTemplateResponseSchema,
 } from '../types/templates/types'
 import { UiExtensionSchema } from '../types/ui-extensions/types'
 import { UserSchema, CurrentUserSchema } from '../types/users/types'
@@ -290,4 +293,16 @@ export const { validate: validateGetTemplateCategoriesResponse } = createValidat
 
 export const { validate: validateGetTemplatesByIdsResponse } = createValidator(
     GetTemplatesByIdsResponseSchema,
+)
+
+export const { validate: validateUpdateUserTemplateResponse } = createValidator(
+    UpdateUserTemplateResponseSchema,
+)
+
+export const { validate: validateDeleteUserTemplateResponse } = createValidator(
+    DeleteUserTemplateResponseSchema,
+)
+
+export const { validate: validatePreviewUserTemplateFromFileResponse } = createValidator(
+    PreviewUserTemplateFromFileResponseSchema,
 )


### PR DESCRIPTION
## Summary

Stacks on top of #603. Adds the full `/templates/user/*` surface to the SDK:

- `createUserTemplate` — `POST /templates/user`
- `updateUserTemplate(id, args)` — `PUT /templates/user/{id}`
- `deleteUserTemplate(id)` — `DELETE /templates/user/{id}`
- `previewUserTemplateFromFile` — `POST /templates/user/preview_from_file` (multipart)
- `createUserTemplateFromFile` — `POST /templates/user/import` (multipart, accepts `uploadedFileName` from a prior preview)


`updateUserTemplate` / `deleteUserTemplate` validate `templateId` is non-empty before any network call and URL-encode the path segment.

## Test plan

- [x] `npm run check` (oxlint + oxfmt) passes
- [x] `npm test` — 602 tests pass (9 new)
- [x] Tests cover JSON payloads (camelCase → snake_case conversion), URL-encoding of the path segment, empty-templateId rejection, multipart additional fields, and `uploadedFileName` pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)