### PR TITLE
fix: pin undici to 7.24.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "emoji-regex": "10.6.0",
                 "form-data": "4.0.5",
                 "ts-custom-error": "^3.2.0",
-                "undici": "^7.16.0",
+                "undici": "7.24.8",
                 "uuid": "11.1.1",
                 "zod": "4.3.6"
             },
@@ -9508,9 +9508,10 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-            "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
             }
@@ -16009,9 +16010,9 @@
             "optional": true
         },
         "undici": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-            "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="
         },
         "undici-types": {
             "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "emoji-regex": "10.6.0",
         "form-data": "4.0.5",
         "ts-custom-error": "^3.2.0",
-        "undici": "^7.16.0",
+        "undici": "7.24.8",
         "uuid": "11.1.1",
         "zod": "4.3.6"
     },


### PR DESCRIPTION
## Summary
- pin undici to 7.24.8 instead of allowing newer 7.x releases
- avoid the Node 26 regression seen with undici 7.27.1 in the decompression dispatcher path

## Validation
- npm run build
- npm test -- src/transport/http-dispatcher.test.ts src/transport/fetch-with-retry.test.ts

Follow-up for Doist/todoist-cli#384: after this is released, todoist-cli should bump to the patched SDK version.