### PR TITLE
chore: block renovate from updating undici

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,12 @@
     "extends": [
         "github>doist/renovate-config:integrations-base",
         "github>doist/renovate-config:integrations-automerge"
+    ],
+    "packageRules": [
+        {
+            "matchPackageNames": ["undici"],
+            "enabled": false,
+            "description": "Pin undici to 7.24.8 - block renovate updates to avoid the Node 26 regression in newer 7.x releases"
+        }
     ]
 }


### PR DESCRIPTION
## Summary
- Disable renovate updates for `undici` so it stays pinned at 7.24.8.

Pinning `undici` in package.json doesn't stop renovate from proposing updates, which would re-introduce the Node 26 regression seen in newer 7.x releases. This adds a `packageRule` to block those updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)