### PR TITLE
fix: build a working dispatcher on runtimes without undici's decompress interceptor (e.g. Bun)

### DIFF
--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -76,6 +76,31 @@ describe('http-dispatcher', () => {
             await new Promise<void>((resolve) => httpServer.close(() => resolve()))
         }
     })
+
+    test('skips the decompress interceptor when the runtime undici lacks it (e.g. Bun)', async () => {
+        // Bun reports `process.versions.node` but ships a partial undici whose
+        // `interceptors.decompress` is absent and whose dispatchers have no
+        // `.compose`. Building the dispatcher must not throw there.
+        vi.resetModules()
+        vi.doMock('undici', () => ({
+            EnvHttpProxyAgent: class {
+                dispatch() {}
+                async close() {}
+            },
+            interceptors: {},
+        }))
+
+        try {
+            const { getDefaultDispatcher: getDispatcher } = await import('./http-dispatcher')
+            const dispatcher = await getDispatcher()
+
+            expect(dispatcher).toBeDefined()
+            expect(typeof dispatcher?.dispatch).toBe('function')
+        } finally {
+            vi.doUnmock('undici')
+            vi.resetModules()
+        }
+    })
 })
 
 describe('suppressExperimentalWarningsSync', () => {

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -44,6 +44,18 @@ async function createDefaultDispatcher(): Promise<Dispatcher> {
     // outside Node, so this branch only runs when undici is safe to load.
     const { EnvHttpProxyAgent, interceptors } = await import('undici')
 
+    const agent = new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
+
+    // Some runtimes report `process.versions.node` (so `isNodeEnvironment()`
+    // passes) but ship only a partial undici: `interceptors.decompress` is
+    // absent and dispatchers have no `.compose`. Bun is the common case. There
+    // the proxy agent alone is enough — Bun's `fetch` decompresses
+    // gzip/deflate/br/zstd natively — so skip the interceptor instead of
+    // crashing on the missing API.
+    if (typeof interceptors.decompress !== 'function') {
+        return agent
+    }
+
     // Compose the response-decompression interceptor so gzip/deflate/br/zstd
     // bodies are decoded before consumers parse them. Required on Node 24+:
     // attaching any custom dispatcher to the global `fetch` strips the
@@ -52,7 +64,7 @@ async function createDefaultDispatcher(): Promise<Dispatcher> {
     // See https://github.com/Doist/todoist-cli/issues/318.
     const decompress = suppressExperimentalWarningsSync(() => interceptors.decompress())
 
-    return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS).compose(decompress)
+    return agent.compose(decompress)
 }
 
 // undici emits an `ExperimentalWarning` the first time `interceptors.decompress()`


### PR DESCRIPTION
## Problem

`getDefaultDispatcher()` gates on `isNodeEnvironment()`, which checks `process.versions.node`. **Bun also sets `process.versions.node`** (for Node compatibility), so under Bun the code takes the Node path and calls `interceptors.decompress()` — an API Bun's built-in undici shim doesn't implement:

```
TypeError: interceptors.decompress is not a function
```

Guarding only that isn't enough: the very next line calls `EnvHttpProxyAgent.prototype.compose`, which Bun's undici also lacks. So the SDK throws while building its default dispatcher and is unusable on Bun. (This is why `@doist/todoist-cli` currently ships a `patchedDependencies` shim against this SDK downstream.)

## Fix

Feature-detect `interceptors.decompress`. When it isn't a function, return the bare `EnvHttpProxyAgent` — Bun's `fetch` decompresses `gzip`/`deflate`/`br`/`zstd` natively, so the proxy agent on its own is already correct. On real Node nothing changes: the decompress interceptor is still composed exactly as before.

It's deliberately a **capability check, not a `Bun` name-check**, so it:
- self-heals automatically if a future Bun implements `interceptors.decompress`, and
- covers any other runtime that reports `process.versions.node` while shipping a partial undici.

## Testing

- Added a unit test that mocks a partial undici (no `decompress`) and asserts the dispatcher still builds. It **fails before this change** (`interceptors.decompress is not a function`) and **passes after**.
- `npm run check` (oxlint + oxfmt), the `http-dispatcher` test suite, and `npm run build` all pass. No behavior change on Node.

Refs the downstream gzip issue: https://github.com/Doist/todoist-cli/issues/318