### PR TITLE
fix: restrict viewAttachment to known attachment hosts

### DIFF
--- a/src/clients/upload-client.ts
+++ b/src/clients/upload-client.ts
@@ -1,7 +1,7 @@
 import { ENDPOINT_REST_UPLOADS } from '../consts/endpoints'
 import { isSuccess, request } from '../transport/http-client'
 import type { Attachment, Comment } from '../types/comments'
-import type { FileResponse } from '../types/http'
+import type { CustomFetch, CustomFetchResponse, FileResponse } from '../types/http'
 import type { DeleteUploadArgs, UploadFileArgs } from '../types/uploads'
 import { wrapAsFileResponse } from '../utils/file-response'
 import { uploadMultipartFile } from '../utils/multipart-upload'
@@ -20,6 +20,72 @@ const AUTHENTICATED_ATTACHMENT_HOST = 'files.todoist.com'
  * third-party infrastructure and must never receive the auth token.
  */
 const CDN_ATTACHMENT_HOSTS = new Set(['todoist.b-cdn.net', 'd1ysz50cxb9zwl.cloudfront.net'])
+
+const MAX_ATTACHMENT_REDIRECTS = 5
+
+/**
+ * Builds the request headers for an attachment fetch, attaching the Bearer
+ * token only when the URL is on the first-party authenticated host.
+ */
+function buildAttachmentAuthHeaders(url: string, authToken: string): Record<string, string> {
+    return new URL(url).hostname === AUTHENTICATED_ATTACHMENT_HOST
+        ? { Authorization: `Bearer ${authToken}` }
+        : {}
+}
+
+/**
+ * Fetches an attachment through a caller-supplied `customFetch` while
+ * guaranteeing the auth token is never sent across origins.
+ *
+ * A `customFetch` is an arbitrary implementation that may not honour the Fetch
+ * standard's rule of stripping `Authorization` on cross-origin redirects (older
+ * `node-fetch`, for example, does not). Because `files.todoist.com` redirects
+ * downloads to the CDN, a naive implementation could forward the token there.
+ * We therefore drive redirects with `redirect: 'manual'` and follow them
+ * ourselves, dropping the auth header whenever the origin changes.
+ *
+ * Implementations that hide the redirect behind an opaque response (status `0`,
+ * e.g. undici and browsers) can't be followed manually; for those we re-issue
+ * with normal redirect following and rely on the Fetch standard's cross-origin
+ * auth stripping, which those runtimes implement.
+ */
+async function customFetchFollowingRedirects(
+    customFetch: CustomFetch,
+    startUrl: string,
+    authToken: string,
+): Promise<CustomFetchResponse> {
+    let currentUrl = startUrl
+    let headers = buildAttachmentAuthHeaders(currentUrl, authToken)
+
+    for (let redirects = 0; redirects < MAX_ATTACHMENT_REDIRECTS; redirects++) {
+        const response = await customFetch(currentUrl, {
+            method: 'GET',
+            headers,
+            redirect: 'manual',
+        })
+
+        const location = response.headers['location']
+        const isReadableRedirect =
+            response.status >= 300 && response.status < 400 && Boolean(location)
+
+        if (!isReadableRedirect) {
+            // Opaque redirect (the impl hid the Location, e.g. undici): re-issue
+            // with normal following and trust the runtime to strip auth cross-origin.
+            if (response.status === 0) {
+                return customFetch(currentUrl, { method: 'GET', headers })
+            }
+            return response
+        }
+
+        const nextUrl = new URL(location as string, currentUrl)
+        if (nextUrl.origin !== new URL(currentUrl).origin) {
+            headers = {}
+        }
+        currentUrl = nextUrl.toString()
+    }
+
+    throw new Error('Too many redirects while fetching attachment')
+}
 
 /**
  * Internal sub-client handling upload + attachment endpoints
@@ -84,13 +150,15 @@ export class UploadClient extends BaseClient {
             throw new Error('Attachment URLs must be on a known Todoist attachment host')
         }
 
-        const fetchOptions: RequestInit = {
-            method: 'GET',
-            headers: isAuthenticatedHost ? { Authorization: `Bearer ${this.authToken}` } : {},
-        }
-
         if (this.customFetch) {
-            const response = await this.customFetch(fileUrl, fetchOptions)
+            // customFetch may not strip auth on cross-origin redirects, so we
+            // follow the files.todoist.com -> CDN hop ourselves to avoid leaking
+            // the token. See customFetchFollowingRedirects for details.
+            const response = await customFetchFollowingRedirects(
+                this.customFetch,
+                fileUrl,
+                this.authToken,
+            )
 
             if (!response.ok) {
                 throw new Error(
@@ -101,6 +169,12 @@ export class UploadClient extends BaseClient {
             return wrapAsFileResponse(response, 'viewAttachment')
         }
 
+        // Built-in fetch (undici) strips Authorization on cross-origin redirects
+        // per the Fetch standard, so the files.todoist.com -> CDN hop is safe here.
+        const fetchOptions: RequestInit = {
+            method: 'GET',
+            headers: isAuthenticatedHost ? { Authorization: `Bearer ${this.authToken}` } : {},
+        }
         const response = await fetch(fileUrl, fetchOptions)
 
         if (!response.ok) {

--- a/src/clients/upload-client.ts
+++ b/src/clients/upload-client.ts
@@ -9,6 +9,19 @@ import { validateAttachment } from '../utils/validators'
 import { BaseClient } from './base-client'
 
 /**
+ * First-party origin that serves attachment downloads behind Bearer auth.
+ * It redirects to the CDN; on the cross-origin hop the runtime drops the
+ * Authorization header, so the token never reaches the CDN.
+ */
+const AUTHENTICATED_ATTACHMENT_HOST = 'files.todoist.com'
+
+/**
+ * CDN origins that serve attachments via pre-signed URLs. These are
+ * third-party infrastructure and must never receive the auth token.
+ */
+const CDN_ATTACHMENT_HOSTS = new Set(['todoist.b-cdn.net', 'd1ysz50cxb9zwl.cloudfront.net'])
+
+/**
  * Internal sub-client handling upload + attachment endpoints
  * (file upload, upload delete, attachment view).
  *
@@ -62,15 +75,18 @@ export class UploadClient extends BaseClient {
             fileUrl = commentOrUrl.fileAttachment.fileUrl
         }
 
-        // Validate the URL belongs to Todoist to prevent leaking the auth token
+        // Only allow known attachment origins, and only attach the auth token to the
+        // first-party authenticated host. This prevents the token leaking to other
+        // todoist.com hosts (e.g. api.todoist.com) or to third-party CDN infrastructure.
         const urlHostname = new URL(fileUrl).hostname
-        if (!urlHostname.endsWith('.todoist.com')) {
-            throw new Error('Attachment URLs must be on a todoist.com domain')
+        const isAuthenticatedHost = urlHostname === AUTHENTICATED_ATTACHMENT_HOST
+        if (!isAuthenticatedHost && !CDN_ATTACHMENT_HOSTS.has(urlHostname)) {
+            throw new Error('Attachment URLs must be on a known Todoist attachment host')
         }
 
         const fetchOptions: RequestInit = {
             method: 'GET',
-            headers: { Authorization: `Bearer ${this.authToken}` },
+            headers: isAuthenticatedHost ? { Authorization: `Bearer ${this.authToken}` } : {},
         }
 
         if (this.customFetch) {

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -1271,9 +1271,14 @@ export class TodoistApi {
      * or a direct file URL string. Returns the raw Response object so the caller
      * can read the body in the appropriate format (.arrayBuffer(), .text(), etc.).
      *
+     * Only known Todoist attachment hosts are allowed: the authenticated
+     * `files.todoist.com` origin (which receives the Bearer token) and the
+     * attachment CDN origins (fetched without the token). Other URLs are rejected.
+     *
      * @param commentOrUrl - A Comment object with a file attachment, or a file URL string.
      * @returns The raw fetch Response for the file content.
-     * @throws Error if a Comment is provided without a file attachment or file URL.
+     * @throws Error if a Comment is provided without a file attachment or file URL,
+     *   or if the URL is not on a known Todoist attachment host.
      *
      * @example
      * ```typescript

--- a/src/todoist-api.ts
+++ b/src/todoist-api.ts
@@ -1256,7 +1256,7 @@ export class TodoistApi {
      * @example
      * ```typescript
      * await api.deleteUpload({
-     *   fileUrl: 'https://cdn.todoist.com/...'
+     *   fileUrl: 'https://files.todoist.com/...'
      * })
      * ```
      */

--- a/src/todoist-api.uploads.test.ts
+++ b/src/todoist-api.uploads.test.ts
@@ -13,7 +13,7 @@ const mockedFs = vi.mocked(fs)
 describe('TodoistApi uploads', () => {
     describe('uploadFile', () => {
         const mockUploadResult = {
-            fileUrl: 'https://cdn.todoist.com/uploads/test-file.pdf',
+            fileUrl: 'https://files.todoist.com/uploads/test-file.pdf',
             fileName: 'test-file.pdf',
             fileSize: 1024,
             fileType: 'application/pdf',
@@ -179,7 +179,7 @@ describe('TodoistApi uploads', () => {
             const api = new TodoistApi('token')
 
             const result = await api.deleteUpload({
-                fileUrl: 'https://cdn.todoist.com/uploads/test-file.pdf',
+                fileUrl: 'https://files.todoist.com/uploads/test-file.pdf',
             })
 
             const capturedRequest = getLastRequest()
@@ -187,7 +187,7 @@ describe('TodoistApi uploads', () => {
             expect(capturedRequest?.method).toBe('DELETE')
             expect(capturedRequest?.headers['authorization']).toBe('Bearer token')
             expect(capturedRequest?.body).toEqual({
-                file_url: 'https://cdn.todoist.com/uploads/test-file.pdf',
+                file_url: 'https://files.todoist.com/uploads/test-file.pdf',
             })
             expect(result).toBe(true)
         })
@@ -211,7 +211,7 @@ describe('TodoistApi uploads', () => {
 
             const result = await api.deleteUpload(
                 {
-                    fileUrl: 'https://cdn.todoist.com/uploads/test-file.pdf',
+                    fileUrl: 'https://files.todoist.com/uploads/test-file.pdf',
                 },
                 requestId,
             )
@@ -222,7 +222,7 @@ describe('TodoistApi uploads', () => {
             expect(capturedRequest?.headers['authorization']).toBe('Bearer token')
             expect(capturedRequest?.headers['x-request-id']).toBe(requestId)
             expect(capturedRequest?.body).toEqual({
-                file_url: 'https://cdn.todoist.com/uploads/test-file.pdf',
+                file_url: 'https://files.todoist.com/uploads/test-file.pdf',
             })
             expect(result).toBe(true)
         })

--- a/src/todoist-api.view-attachment.test.ts
+++ b/src/todoist-api.view-attachment.test.ts
@@ -238,8 +238,114 @@ describe('TodoistApi viewAttachment', () => {
             expect(mockCustomFetch).toHaveBeenCalledWith(FILE_URL, {
                 method: 'GET',
                 headers: { Authorization: 'Bearer test-token' },
+                redirect: 'manual',
             })
             expect(await response.text()).toBe('custom fetch content')
+        })
+
+        test('omits the auth token for CDN URLs', async () => {
+            const cdnUrl = 'https://todoist.b-cdn.net/uploads/file.png'
+            const mockCustomFetch =
+                vi.fn<(url: string, init?: RequestInit) => Promise<CustomFetchResponse>>()
+            mockCustomFetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'image/png' },
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve({}),
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+            })
+
+            const api = new TodoistApi('test-token', { customFetch: mockCustomFetch })
+            await api.viewAttachment(cdnUrl)
+
+            expect(mockCustomFetch).toHaveBeenCalledWith(cdnUrl, {
+                method: 'GET',
+                headers: {},
+                redirect: 'manual',
+            })
+        })
+
+        test('follows a cross-origin redirect without forwarding the auth token', async () => {
+            const cdnUrl = 'https://todoist.b-cdn.net/uploads/file.png'
+            const mockCustomFetch =
+                vi.fn<(url: string, init?: RequestInit) => Promise<CustomFetchResponse>>()
+            // files.todoist.com responds with a redirect to the CDN...
+            mockCustomFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 302,
+                statusText: 'Found',
+                headers: { location: cdnUrl },
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve({}),
+            })
+            // ...and the CDN serves the file.
+            mockCustomFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'image/png' },
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve({}),
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+            })
+
+            const api = new TodoistApi('test-token', { customFetch: mockCustomFetch })
+            const response = await api.viewAttachment(FILE_URL)
+
+            expect(mockCustomFetch).toHaveBeenNthCalledWith(1, FILE_URL, {
+                method: 'GET',
+                headers: { Authorization: 'Bearer test-token' },
+                redirect: 'manual',
+            })
+            // The hop to the CDN must not carry the token.
+            expect(mockCustomFetch).toHaveBeenNthCalledWith(2, cdnUrl, {
+                method: 'GET',
+                headers: {},
+                redirect: 'manual',
+            })
+            expect(response.ok).toBe(true)
+        })
+
+        test('falls back to normal redirect following for opaque redirects', async () => {
+            const mockCustomFetch =
+                vi.fn<(url: string, init?: RequestInit) => Promise<CustomFetchResponse>>()
+            // An opaque redirect (e.g. undici): status 0, no readable Location.
+            mockCustomFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 0,
+                statusText: '',
+                headers: {},
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve({}),
+            })
+            // The fallback request (normal following) returns the file.
+            mockCustomFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'image/png' },
+                text: () => Promise.resolve(''),
+                json: () => Promise.resolve({}),
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+            })
+
+            const api = new TodoistApi('test-token', { customFetch: mockCustomFetch })
+            const response = await api.viewAttachment(FILE_URL)
+
+            expect(mockCustomFetch).toHaveBeenNthCalledWith(1, FILE_URL, {
+                method: 'GET',
+                headers: { Authorization: 'Bearer test-token' },
+                redirect: 'manual',
+            })
+            // Fallback re-issues without redirect: 'manual', relying on the
+            // runtime to strip auth on the cross-origin hop.
+            expect(mockCustomFetch).toHaveBeenNthCalledWith(2, FILE_URL, {
+                method: 'GET',
+                headers: { Authorization: 'Bearer test-token' },
+            })
+            expect(response.ok).toBe(true)
         })
 
         test('returns binary arrayBuffer from custom fetch byte-for-byte', async () => {

--- a/src/todoist-api.view-attachment.test.ts
+++ b/src/todoist-api.view-attachment.test.ts
@@ -152,33 +152,68 @@ describe('TodoistApi viewAttachment', () => {
             expect(response.ok).toBe(true)
         })
 
-        test('allows subdomains of todoist.com', async () => {
-            const url = 'https://cdn.todoist.com/uploads/file.png'
+        test('allows BunnyCDN URLs without sending the auth token', async () => {
+            const url = 'https://todoist.b-cdn.net/uploads/file.png'
             server.use(
-                http.get(url, () => {
+                http.get(url, ({ request }) => {
+                    captureRequest({ request, body: null })
                     return new HttpResponse('data', { status: 200 })
                 }),
             )
 
             const api = new TodoistApi('test-token')
             const response = await api.viewAttachment(url)
+
             expect(response.ok).toBe(true)
+            expect(getLastRequest()?.headers['authorization']).toBeUndefined()
         })
 
-        test('rejects non-todoist.com URLs', async () => {
+        test('allows CloudFront URLs without sending the auth token', async () => {
+            const url = 'https://d1ysz50cxb9zwl.cloudfront.net/uploads/file.png'
+            server.use(
+                http.get(url, ({ request }) => {
+                    captureRequest({ request, body: null })
+                    return new HttpResponse('data', { status: 200 })
+                }),
+            )
+
+            const api = new TodoistApi('test-token')
+            const response = await api.viewAttachment(url)
+
+            expect(response.ok).toBe(true)
+            expect(getLastRequest()?.headers['authorization']).toBeUndefined()
+        })
+
+        test('rejects api.todoist.com URLs', async () => {
+            const api = new TodoistApi('test-token')
+
+            await expect(
+                api.viewAttachment('https://api.todoist.com/api/v1/tasks'),
+            ).rejects.toThrow('Attachment URLs must be on a known Todoist attachment host')
+        })
+
+        test('rejects other todoist.com subdomains', async () => {
+            const api = new TodoistApi('test-token')
+
+            await expect(
+                api.viewAttachment('https://cdn.todoist.com/uploads/file.png'),
+            ).rejects.toThrow('Attachment URLs must be on a known Todoist attachment host')
+        })
+
+        test('rejects non-todoist URLs', async () => {
             const api = new TodoistApi('test-token')
 
             await expect(api.viewAttachment('https://evil.com/steal-token')).rejects.toThrow(
-                'Attachment URLs must be on a todoist.com domain',
+                'Attachment URLs must be on a known Todoist attachment host',
             )
         })
 
-        test('rejects URLs with todoist.com as a suffix of another domain', async () => {
+        test('rejects URLs with a known host as a suffix of another domain', async () => {
             const api = new TodoistApi('test-token')
 
-            await expect(api.viewAttachment('https://nottodoist.com/file.png')).rejects.toThrow(
-                'Attachment URLs must be on a todoist.com domain',
-            )
+            await expect(
+                api.viewAttachment('https://files.todoist.com.evil.com/file.png'),
+            ).rejects.toThrow('Attachment URLs must be on a known Todoist attachment host')
         })
     })
 


### PR DESCRIPTION
## Summary

`viewAttachment` previously accepted any `*.todoist.com` host and forwarded the caller's Bearer token to it. Because `api.todoist.com` ends in `.todoist.com`, the host check let the attachment viewer fetch arbitrary authenticated API responses rather than just attachment downloads.

This replaces the suffix check with an explicit host allowlist:

- **`files.todoist.com`** — the authenticated download origin, which still receives the Bearer token. It redirects to the CDN, and the runtime drops the `Authorization` header on the cross-origin hop, so the token never reaches the CDN.
- **`todoist.b-cdn.net`** and **`d1ysz50cxb9zwl.cloudfront.net`** — the attachment CDN origins, fetched *without* the token since they serve pre-signed URLs and are third-party infrastructure that must never see a Todoist token.

Everything else — including `api.todoist.com`, `app.todoist.com`, and other `*.todoist.com` subdomains — is now rejected.

## Why

Raised in [Doist/Issues#20430](https://github.com/Doist/Issues/issues/20430). The original report framed this as an authenticated boundary bypass; in practice the hosted MCP token only carries `data:read_write`, so there's no privilege escalation. But two things were worth fixing regardless:

1. A tool called "view attachment" should not be able to return arbitrary `api.todoist.com` JSON.
2. The old check would have *rejected* the CDN hosts entirely; allowing them needed to come without leaking the token to third-party CDN infrastructure.

## Tests

Updated `view-attachment` tests to cover:
- CDN hosts fetched without the auth token
- `api.todoist.com` rejected
- other `*.todoist.com` subdomains rejected
- suffix-spoof (`files.todoist.com.evil.com`) rejected

Full suite green (623 tests), lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)