### PR TITLE
feat(sections,projects): model description on read and write types

### DIFF
--- a/src/test-utils/test-defaults.ts
+++ b/src/test-utils/test-defaults.ts
@@ -216,6 +216,7 @@ export const DEFAULT_SECTION: Section = {
     updatedAt: new Date('2025-03-28T14:01:23.334885Z'),
     archivedAt: null,
     name: DEFAULT_SECTION_NAME,
+    description: null,
     sectionOrder: DEFAULT_ORDER,
     isArchived: false,
     isDeleted: false,

--- a/src/todoist-api.projects.test.ts
+++ b/src/todoist-api.projects.test.ts
@@ -29,11 +29,24 @@ import {
     DEFAULT_NOTE,
     DEFAULT_WORKSPACE_PROJECT,
 } from './test-utils/test-defaults'
+import type { UpdateProjectArgs } from './types/projects/requests'
 import { getProjectUrl } from './utils/url-helpers'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
 }
+
+describe('UpdateProjectArgs type contract', () => {
+    test('rejects a null description (projects clear with "", not null)', () => {
+        // Projects use NULL_KEEPS_UNCHANGED: clearing is an empty string, and
+        // `null` would mean "leave unchanged" — so the type must not accept it.
+        // @ts-expect-error description is `string | undefined`, not nullable
+        const nulled: UpdateProjectArgs = { description: null }
+        const cleared: UpdateProjectArgs = { description: '' }
+        const cases = [nulled, cleared]
+        expect(cases).toHaveLength(2)
+    })
+})
 
 describe('TodoistApi project endpoints', () => {
     describe('getProject', () => {

--- a/src/todoist-api.projects.test.ts
+++ b/src/todoist-api.projects.test.ts
@@ -125,6 +125,21 @@ describe('TodoistApi project endpoints', () => {
 
             expect(project).toEqual(DEFAULT_PROJECT)
         })
+
+        test('forwards description in the request body', async () => {
+            let capturedBody: unknown
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}`, async ({ request }) => {
+                    capturedBody = await request.json()
+                    return HttpResponse.json(DEFAULT_PROJECT, { status: 200 })
+                }),
+            )
+            const api = getTarget()
+
+            await api.addProject({ ...DEFAULT_ADD_PROJECT_ARGS, description: 'Quarterly OKRs' })
+
+            expect(capturedBody).toMatchObject({ description: 'Quarterly OKRs' })
+        })
     })
 
     describe('updateProject', () => {
@@ -170,6 +185,26 @@ describe('TodoistApi project endpoints', () => {
 
             expect(capturedBodies[0]).toEqual({ folder_id: '42' })
             expect(capturedBodies[1]).toEqual({ folder_id: null })
+        })
+
+        test('forwards description, sending an empty string to clear it', async () => {
+            const capturedBodies: unknown[] = []
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}/123`,
+                    async ({ request }) => {
+                        capturedBodies.push(await request.json())
+                        return HttpResponse.json(DEFAULT_WORKSPACE_PROJECT, { status: 200 })
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            await api.updateProject('123', { description: 'Updated scope' })
+            await api.updateProject('123', { description: '' })
+
+            expect(capturedBodies[0]).toEqual({ description: 'Updated scope' })
+            expect(capturedBodies[1]).toEqual({ description: '' })
         })
     })
 

--- a/src/todoist-api.sections.test.ts
+++ b/src/todoist-api.sections.test.ts
@@ -8,11 +8,26 @@ import {
 } from './consts/endpoints'
 import { server, http, HttpResponse } from './test-utils/msw-setup'
 import { DEFAULT_AUTH_TOKEN, DEFAULT_SECTION } from './test-utils/test-defaults'
+import type { UpdateSectionArgs } from './types/sections/requests'
 import { getSectionUrl } from './utils/url-helpers'
 
 function getTarget() {
     return new TodoistApi(DEFAULT_AUTH_TOKEN)
 }
+
+describe('UpdateSectionArgs type contract', () => {
+    test('rejects empty / all-undefined updates while allowing a name or null clear', () => {
+        // @ts-expect-error an empty update would serialize to an empty body
+        const empty: UpdateSectionArgs = {}
+        // @ts-expect-error an all-undefined update would serialize to an empty body
+        const allUndefined: UpdateSectionArgs = { name: undefined }
+        const nameOnly: UpdateSectionArgs = { name: 'Renamed' }
+        const clear: UpdateSectionArgs = { description: null }
+        // Reference each so the @ts-expect-error lines are the only contract here.
+        const cases = [empty, allUndefined, nameOnly, clear]
+        expect(cases).toHaveLength(4)
+    })
+})
 
 describe('TodoistApi section endpoints', () => {
     describe('getSection', () => {

--- a/src/todoist-api.sections.test.ts
+++ b/src/todoist-api.sections.test.ts
@@ -150,48 +150,24 @@ describe('TodoistApi section endpoints', () => {
             expect(response).toEqual(returnedSection)
         })
 
-        test('supports a description-only update (no name) and forwards it', async () => {
-            let capturedBody: unknown
+        test('forwards a description-only update and a null clear (no name sent)', async () => {
+            const capturedBodies: unknown[] = []
             server.use(
                 http.post(
                     `${getSyncBaseUri()}${ENDPOINT_REST_SECTIONS}/123`,
                     async ({ request }) => {
-                        capturedBody = await request.json()
-                        return HttpResponse.json(
-                            { ...DEFAULT_SECTION, id: '123', description: 'Sprint backlog' },
-                            { status: 200 },
-                        )
+                        capturedBodies.push(await request.json())
+                        return HttpResponse.json({ ...DEFAULT_SECTION, id: '123' }, { status: 200 })
                     },
                 ),
             )
             const api = getTarget()
 
-            const response = await api.updateSection('123', { description: 'Sprint backlog' })
+            await api.updateSection('123', { description: 'Sprint backlog' })
+            await api.updateSection('123', { description: null })
 
-            expect(capturedBody).toEqual({ description: 'Sprint backlog' })
-            expect(response.description).toBe('Sprint backlog')
-        })
-
-        test('clears the description when passed null', async () => {
-            let capturedBody: unknown
-            server.use(
-                http.post(
-                    `${getSyncBaseUri()}${ENDPOINT_REST_SECTIONS}/123`,
-                    async ({ request }) => {
-                        capturedBody = await request.json()
-                        return HttpResponse.json(
-                            { ...DEFAULT_SECTION, id: '123', description: null },
-                            { status: 200 },
-                        )
-                    },
-                ),
-            )
-            const api = getTarget()
-
-            const response = await api.updateSection('123', { description: null })
-
-            expect(capturedBody).toEqual({ description: null })
-            expect(response.description).toBeNull()
+            expect(capturedBodies[0]).toEqual({ description: 'Sprint backlog' })
+            expect(capturedBodies[1]).toEqual({ description: null })
         })
     })
 

--- a/src/todoist-api.sections.test.ts
+++ b/src/todoist-api.sections.test.ts
@@ -89,6 +89,28 @@ describe('TodoistApi section endpoints', () => {
 
             expect(section).toEqual(DEFAULT_SECTION)
         })
+
+        test('forwards description in the request body', async () => {
+            let capturedBody: unknown
+            server.use(
+                http.post(`${getSyncBaseUri()}${ENDPOINT_REST_SECTIONS}`, async ({ request }) => {
+                    capturedBody = await request.json()
+                    return HttpResponse.json(
+                        { ...DEFAULT_SECTION, description: 'Bugs to verify' },
+                        { status: 200 },
+                    )
+                }),
+            )
+            const api = getTarget()
+
+            const section = await api.addSection({
+                ...DEFAULT_ADD_SECTION_ARGS,
+                description: 'Bugs to verify',
+            })
+
+            expect(capturedBody).toMatchObject({ description: 'Bugs to verify' })
+            expect(section.description).toBe('Bugs to verify')
+        })
     })
 
     describe('updateSection', () => {
@@ -111,6 +133,50 @@ describe('TodoistApi section endpoints', () => {
             const response = await api.updateSection('123', DEFAULT_UPDATE_SECTION_ARGS)
 
             expect(response).toEqual(returnedSection)
+        })
+
+        test('supports a description-only update (no name) and forwards it', async () => {
+            let capturedBody: unknown
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_SECTIONS}/123`,
+                    async ({ request }) => {
+                        capturedBody = await request.json()
+                        return HttpResponse.json(
+                            { ...DEFAULT_SECTION, id: '123', description: 'Sprint backlog' },
+                            { status: 200 },
+                        )
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            const response = await api.updateSection('123', { description: 'Sprint backlog' })
+
+            expect(capturedBody).toEqual({ description: 'Sprint backlog' })
+            expect(response.description).toBe('Sprint backlog')
+        })
+
+        test('clears the description when passed null', async () => {
+            let capturedBody: unknown
+            server.use(
+                http.post(
+                    `${getSyncBaseUri()}${ENDPOINT_REST_SECTIONS}/123`,
+                    async ({ request }) => {
+                        capturedBody = await request.json()
+                        return HttpResponse.json(
+                            { ...DEFAULT_SECTION, id: '123', description: null },
+                            { status: 200 },
+                        )
+                    },
+                ),
+            )
+            const api = getTarget()
+
+            const response = await api.updateSection('123', { description: null })
+
+            expect(capturedBody).toEqual({ description: null })
+            expect(response.description).toBeNull()
         })
     })
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -7,12 +7,17 @@ type SearchArgs = {
 }
 
 /**
- * Requires at least one of the keys in `Keys` to be present, while keeping the
- * rest optional. Used for update-args types where every field is individually
- * optional but an empty `{}` update should not type-check.
+ * Requires at least one of the keys in `Keys` to be present *with a defined
+ * value*, while keeping the rest optional. Used for update-args types where
+ * every field is individually optional but an empty `{}` update — or one that
+ * only carries `undefined` values (which serialize to an empty body) — should
+ * not type-check. `null` is preserved where the field type allows it (e.g. a
+ * `description?: string | null` clear).
  */
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
-    { [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>> }[Keys]
+    {
+        [K in Keys]-?: { [P in K]-?: Exclude<T[P], undefined> } & Partial<Pick<T, Exclude<Keys, K>>>
+    }[Keys]
 
 /**
  * Zod schema that accepts both string and number values and coerces to string.

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -7,23 +7,10 @@ type SearchArgs = {
 }
 
 /**
- * Requires at least one of the keys in `Keys` to be present *with a defined
- * value*, while keeping the rest optional. Used for update-args types where
- * every field is individually optional but an empty `{}` update — or one that
- * only carries `undefined` values (which serialize to an empty body) — should
- * not type-check. `null` is preserved where the field type allows it (e.g. a
- * `description?: string | null` clear).
- */
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
-    {
-        [K in Keys]-?: { [P in K]-?: Exclude<T[P], undefined> } & Partial<Pick<T, Exclude<Keys, K>>>
-    }[Keys]
-
-/**
  * Zod schema that accepts both string and number values and coerces to string.
  * The REST API returns numeric IDs while the Sync API returns string IDs.
  */
 const StringOrNumberSchema = z.union([z.string(), z.number()]).transform((val) => String(val))
 
 export { StringOrNumberSchema }
-export type { RequireAtLeastOne, SearchArgs }
+export type { SearchArgs }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -7,10 +7,18 @@ type SearchArgs = {
 }
 
 /**
+ * Requires at least one of the keys in `Keys` to be present, while keeping the
+ * rest optional. Used for update-args types where every field is individually
+ * optional but an empty `{}` update should not type-check.
+ */
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
+    { [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>> }[Keys]
+
+/**
  * Zod schema that accepts both string and number values and coerces to string.
  * The REST API returns numeric IDs while the Sync API returns string IDs.
  */
 const StringOrNumberSchema = z.union([z.string(), z.number()]).transform((val) => String(val))
 
 export { StringOrNumberSchema }
-export type { SearchArgs }
+export type { RequireAtLeastOne, SearchArgs }

--- a/src/types/projects/requests.ts
+++ b/src/types/projects/requests.ts
@@ -71,6 +71,8 @@ export type AddProjectArgs = {
     isFavorite?: boolean
     viewStyle?: ProjectViewStyle
     workspaceId?: string
+    /** Optional description for the project (Markdown). */
+    description?: string
 }
 
 /**
@@ -82,6 +84,11 @@ export type UpdateProjectArgs = {
     color?: ColorKey
     isFavorite?: boolean
     viewStyle?: ProjectViewStyle
+    /**
+     * Updated project description (Markdown). Pass an empty string to clear it.
+     * Omit this field to keep it unchanged.
+     */
+    description?: string
     /**
      * Folder to move the project into. Only supported for workspace projects.
      * Pass `null` to clear the value. Omit this field to keep it unchanged.

--- a/src/types/sections/requests.ts
+++ b/src/types/sections/requests.ts
@@ -33,6 +33,8 @@ export type AddSectionArgs = {
     name: string
     projectId: string
     order?: number | null
+    /** Optional description for the section (Markdown). */
+    description?: string
 }
 
 /**
@@ -40,5 +42,10 @@ export type AddSectionArgs = {
  * @see https://developer.todoist.com/api/v1/#tag/Sections/operation/update_section_api_v1_sections__section_id__post
  */
 export type UpdateSectionArgs = {
-    name: string
+    name?: string
+    /**
+     * Updated section description (Markdown). Pass `null` to clear it. Omit the
+     * field to keep it unchanged.
+     */
+    description?: string | null
 }

--- a/src/types/sections/requests.ts
+++ b/src/types/sections/requests.ts
@@ -1,4 +1,4 @@
-import type { SearchArgs } from '../common'
+import type { RequireAtLeastOne, SearchArgs } from '../common'
 import type { Section } from './types'
 
 /**
@@ -38,14 +38,14 @@ export type AddSectionArgs = {
 }
 
 /**
- * Arguments for updating a section.
+ * Arguments for updating a section. At least one field must be provided.
  * @see https://developer.todoist.com/api/v1/#tag/Sections/operation/update_section_api_v1_sections__section_id__post
  */
-export type UpdateSectionArgs = {
+export type UpdateSectionArgs = RequireAtLeastOne<{
     name?: string
     /**
      * Updated section description (Markdown). Pass `null` to clear it. Omit the
      * field to keep it unchanged.
      */
     description?: string | null
-}
+}>

--- a/src/types/sections/requests.ts
+++ b/src/types/sections/requests.ts
@@ -1,4 +1,5 @@
-import type { RequireAtLeastOne, SearchArgs } from '../common'
+import type { RequireAtLeastOne } from 'type-fest'
+import type { SearchArgs } from '../common'
 import type { Section } from './types'
 
 /**
@@ -42,10 +43,10 @@ export type AddSectionArgs = {
  * @see https://developer.todoist.com/api/v1/#tag/Sections/operation/update_section_api_v1_sections__section_id__post
  */
 export type UpdateSectionArgs = RequireAtLeastOne<{
-    name?: string
+    name: string
     /**
      * Updated section description (Markdown). Pass `null` to clear it. Omit the
      * field to keep it unchanged.
      */
-    description?: string | null
+    description: string | null
 }>

--- a/src/types/sections/types.ts
+++ b/src/types/sections/types.ts
@@ -14,6 +14,7 @@ export const SectionBaseSchema = z.object({
     updatedAt: z.coerce.date(),
     archivedAt: z.coerce.date().nullable(),
     name: z.string(),
+    description: z.string().nullable(),
     sectionOrder: z.number().int(),
     isArchived: z.boolean(),
     isDeleted: z.boolean(),

--- a/src/types/webhooks/sections.test.ts
+++ b/src/types/webhooks/sections.test.ts
@@ -58,6 +58,15 @@ describe('section:* payloads', () => {
         expect(payload.eventData.description).toBeNull()
     })
 
+    test('tolerates an explicit null description', () => {
+        const payload = parseWebhookPayload(
+            envelope('section:added', rawSection({ description: null })),
+        )
+        if (payload.eventName !== 'section:added') throw new Error('expected section:added')
+
+        expect(payload.eventData.description).toBeNull()
+    })
+
     test('section:deleted tolerates a null updatedAt', () => {
         const payload = parseWebhookPayload(
             envelope(

--- a/src/types/webhooks/sections.test.ts
+++ b/src/types/webhooks/sections.test.ts
@@ -41,6 +41,23 @@ describe('section:* payloads', () => {
         expect(payload.eventData.name).toBe('Renamed')
     })
 
+    test('surfaces a section description when present', () => {
+        const payload = parseWebhookPayload(
+            envelope('section:updated', rawSection({ description: 'Sprint notes' })),
+        )
+        if (payload.eventName !== 'section:updated') throw new Error('expected section:updated')
+
+        expect(payload.eventData.description).toBe('Sprint notes')
+    })
+
+    test('tolerates a missing description key (normalises to null)', () => {
+        // rawSection() omits description, mirroring leaner webhook payloads.
+        const payload = parseWebhookPayload(envelope('section:added', rawSection()))
+        if (payload.eventName !== 'section:added') throw new Error('expected section:added')
+
+        expect(payload.eventData.description).toBeNull()
+    })
+
     test('section:deleted tolerates a null updatedAt', () => {
         const payload = parseWebhookPayload(
             envelope(

--- a/src/types/webhooks/sections.ts
+++ b/src/types/webhooks/sections.ts
@@ -33,12 +33,17 @@ export const SECTION_WEBHOOK_EVENTS = [
  * payloads that deliver it as `null` or omit the key entirely — tombstones
  * and never-updated sections come through without an `updated_at` value.
  * The result is normalised to `Date | null` so consumers don't have to
- * handle three shapes. Surfaces the computed `url` so the exposed shape
- * matches {@link Section}.
+ * handle three shapes. `description` is similarly tolerated (older webhook
+ * payloads may omit it) and normalised to `string | null`. Surfaces the
+ * computed `url` so the exposed shape matches {@link Section}.
  */
 export const WebhookSectionSchema = SectionBaseSchema.extend({
     updatedAt: z.coerce
         .date()
+        .nullish()
+        .transform((value) => value ?? null),
+    description: z
+        .string()
         .nullish()
         .transform((value) => value ?? null),
 }).transform((data) => ({

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -138,6 +138,13 @@ describe('validators', () => {
                 validateSection(INVALID_SECTION)
             }).toThrow(ZodError)
         })
+
+        test('validation rejects a section missing description (non-webhook reads are strict)', () => {
+            const { description: _description, ...withoutDescription } = DEFAULT_SECTION
+            expect(() => {
+                validateSection(withoutDescription)
+            }).toThrow(ZodError)
+        })
     })
 
     describe('validateSectionArray', () => {


### PR DESCRIPTION
## What

Models project and section `description` (26Q2 Project Essentials) on the SDK's read and write types. The backend shipped both (sections landed 2026-06-10 via [Todoist#28403](https://github.com/Doist/Todoist/pull/28403)), but the SDK didn't model the section side and omitted `description` from the write args — so the CLI and MCP currently need casts and can't read section descriptions at all. This unblocks them.

## Changes

**Sections**
- `SectionBaseSchema` gains `description: z.string().nullable()` — the backend column is `str | None` (null when unset), so REST and sync section reads now carry it.
- `WebhookSectionSchema` overrides `description` to tolerate omission (`.nullish()` → `null`), mirroring the existing `updatedAt` handling, so leaner webhook payloads still parse.
- `AddSectionArgs` gains optional `description`; `UpdateSectionArgs` makes `name` optional and adds `description?: string | null` (`null` clears, matching the backend's `NULL_CLEARS`), enabling description-only updates.

**Projects**
- `AddProjectArgs` / `UpdateProjectArgs` gain optional `description` (empty string clears on update, matching `NULL_KEEPS_UNCHANGED`). The project read schema already carried `description`, so no read change there.

## Clear-semantics note (intentional asymmetry, from the backend)

- Project update: omit `description` to keep, `""` to clear.
- Section update: omit to keep, `null` to clear.

These mirror the backend's `NULL_KEEPS_UNCHANGED` (projects) vs `NULL_CLEARS` (sections) contracts and are documented in the arg JSDoc.

## Testing

- Read parsing for `description` (string and `null`).
- Webhook tolerance: present description surfaces; missing key normalises to `null`.
- `addSection` / `updateSection` and `addProject` / `updateProject` forward `description` in the request body, including the section `null`-clear and project `""`-clear paths, plus a description-only section update (no `name`).
- Full suite green (633 tests), lint/format, build all pass. (The 4 pre-existing `ts-compile-check` errors in apps/ui-extensions tests are unrelated to this change and present on `main`.)

## Downstream

Unblocks the draft consumer PRs: CLI [todoist-cli#395](https://github.com/Doist/todoist-cli/pull/395)/[#396](https://github.com/Doist/todoist-cli/pull/396) and MCP [todoist-mcp#500](https://github.com/Doist/todoist-mcp/pull/500)/[#501](https://github.com/Doist/todoist-mcp/pull/501). Draft until reviewed; once released, bump the pins there to drop the temporary casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
