### PR TITLE
feat: add refreshAuthToken helper for refreshing access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ const refreshed = await refreshAuthToken({
 // when present, otherwise keep using the previous one.
 ```
 
+> **Note:** Refresh tokens are only issued to OAuth apps that have them enabled.
+> This is on by default for new apps; legacy apps must opt in. Apps without
+> refresh tokens receive a non-expiring access token, so `getAuthToken` returns
+> no `refreshToken`/`expiresIn` and there is nothing to refresh.
+
 ### Important Notes
 
 - All existing transforms (snake_case ↔ camelCase) work automatically with custom fetch

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ await revokeToken(args, {
 const { accessToken } = await getAuthToken(args, baseUrl)
 ```
 
+When the authorization server issues a `refreshToken`, use `refreshAuthToken`
+to obtain a new access token once the current one expires, without sending the
+user back through the authorization flow:
+
+```typescript
+const refreshed = await refreshAuthToken({
+    clientId: 'your-client-id',
+    clientSecret: 'your-client-secret',
+    refreshToken: storedRefreshToken,
+})
+
+// The server may rotate the refresh token — persist refreshed.refreshToken
+// when present, otherwise keep using the previous one.
+```
+
 ### Important Notes
 
 - All existing transforms (snake_case ↔ camelCase) work automatically with custom fetch

--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ const refreshed = await refreshAuthToken({
 // when present, otherwise keep using the previous one.
 ```
 
-> **Note:** Refresh tokens are only issued to OAuth apps that have them enabled.
-> This is on by default for new apps; legacy apps must opt in. Apps without
-> refresh tokens receive a non-expiring access token, so `getAuthToken` returns
-> no `refreshToken`/`expiresIn` and there is nothing to refresh.
+> **Note:** Refresh tokens are only issued to OAuth apps that have them enabled
+> (the default for new apps). Apps without them receive a long-lived access
+> token, so `getAuthToken` returns no `refreshToken` and there is nothing to
+> refresh. For public clients (`tokenEndpointAuthMethod: 'none'`), omit
+> `clientSecret` when calling `refreshAuthToken`.
 
 ### Important Notes
 

--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -1,6 +1,7 @@
 import {
     getAuthorizationUrl,
     getAuthToken,
+    refreshAuthToken,
     revokeToken,
     migratePersonalToken,
     registerClient,
@@ -130,6 +131,84 @@ describe('authentication', () => {
                 assertInstance(e, TodoistRequestError)
                 expect(e.message).toEqual('Authentication token exchange failed.')
                 expect(e.responseData).toEqual(missingTokenResponse)
+            }
+        })
+    })
+
+    describe('refreshAuthToken', () => {
+        const defaultRefreshRequest = {
+            clientId: 'SomeId',
+            clientSecret: 'ASecret',
+            refreshToken: 'ARefreshToken',
+        }
+
+        test('exchanges a refresh token for a new access token', async () => {
+            let capturedBody: unknown = null
+
+            server.use(
+                http.post('https://todoist.com/oauth/access_token', async ({ request }) => {
+                    capturedBody = await request.json()
+                    return HttpResponse.json(
+                        {
+                            accessToken: 'ANewToken',
+                            tokenType: 'Bearer',
+                            refreshToken: 'ANewRefreshToken',
+                            expiresIn: 3600,
+                        },
+                        { status: 200 },
+                    )
+                }),
+            )
+
+            const tokenResponse = await refreshAuthToken(defaultRefreshRequest)
+
+            expect(capturedBody).toEqual({
+                client_id: 'SomeId',
+                client_secret: 'ASecret',
+                refresh_token: 'ARefreshToken',
+                grant_type: 'refresh_token',
+            })
+            expect(tokenResponse).toEqual({
+                accessToken: 'ANewToken',
+                tokenType: 'Bearer',
+                refreshToken: 'ANewRefreshToken',
+                expiresIn: 3600,
+            })
+        })
+
+        test('uses custom base URL when provided', async () => {
+            server.use(
+                http.post('https://staging.todoist.com/oauth/access_token', () => {
+                    return HttpResponse.json(
+                        { accessToken: 'ANewToken', tokenType: 'Bearer' },
+                        { status: 200 },
+                    )
+                }),
+            )
+
+            const tokenResponse = await refreshAuthToken(defaultRefreshRequest, {
+                baseUrl: 'https://staging.todoist.com',
+            })
+
+            expect(tokenResponse.accessToken).toEqual('ANewToken')
+        })
+
+        test('throws error if non 200 response', async () => {
+            const failureStatus = 400
+            server.use(
+                http.post('https://todoist.com/oauth/access_token', () => {
+                    return HttpResponse.json(undefined, { status: failureStatus })
+                }),
+            )
+
+            expect.assertions(2)
+
+            try {
+                await refreshAuthToken(defaultRefreshRequest)
+            } catch (e: unknown) {
+                assertInstance(e, TodoistRequestError)
+                expect(e.message).toEqual('Authentication token refresh failed.')
+                expect(e.httpStatusCode).toEqual(failureStatus)
             }
         })
     })

--- a/src/authentication.test.ts
+++ b/src/authentication.test.ts
@@ -193,6 +193,28 @@ describe('authentication', () => {
             expect(tokenResponse.accessToken).toEqual('ANewToken')
         })
 
+        test('omits client_secret for public clients', async () => {
+            let capturedBody: unknown = null
+
+            server.use(
+                http.post('https://todoist.com/oauth/access_token', async ({ request }) => {
+                    capturedBody = await request.json()
+                    return HttpResponse.json(
+                        { accessToken: 'ANewToken', tokenType: 'Bearer' },
+                        { status: 200 },
+                    )
+                }),
+            )
+
+            await refreshAuthToken({ clientId: 'SomeId', refreshToken: 'ARefreshToken' })
+
+            expect(capturedBody).toEqual({
+                client_id: 'SomeId',
+                refresh_token: 'ARefreshToken',
+                grant_type: 'refresh_token',
+            })
+        })
+
         test('throws error if non 200 response', async () => {
             const failureStatus = 400
             server.use(
@@ -209,6 +231,29 @@ describe('authentication', () => {
                 assertInstance(e, TodoistRequestError)
                 expect(e.message).toEqual('Authentication token refresh failed.')
                 expect(e.httpStatusCode).toEqual(failureStatus)
+            }
+        })
+
+        test('throws error if token not present in response', async () => {
+            const missingTokenResponse = {
+                accessToken: undefined,
+                tokenType: undefined,
+            }
+
+            server.use(
+                http.post('https://todoist.com/oauth/access_token', () => {
+                    return HttpResponse.json(missingTokenResponse, { status: 200 })
+                }),
+            )
+
+            expect.assertions(2)
+
+            try {
+                await refreshAuthToken(defaultRefreshRequest)
+            } catch (e: unknown) {
+                assertInstance(e, TodoistRequestError)
+                expect(e.message).toEqual('Authentication token refresh failed.')
+                expect(e.responseData).toEqual(missingTokenResponse)
             }
         })
     })

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -110,6 +110,20 @@ export type AuthTokenRequestArgs = {
 export type AuthTokenResponse = {
     accessToken: string
     tokenType: string
+    /** Refresh token, when the authorization server issues one. */
+    refreshToken?: string
+    /** Access token lifetime in seconds, when provided. */
+    expiresIn?: number
+}
+
+/**
+ * Parameters required to exchange a refresh token for a new access token.
+ * @see https://developer.todoist.com/api/v1/#tag/Authorization/OAuth
+ */
+export type RefreshTokenRequestArgs = {
+    clientId: string
+    clientSecret: string
+    refreshToken: string
 }
 
 /**
@@ -268,6 +282,70 @@ export async function getAuthToken(
         const err = error as TodoistRequestError
         throw new TodoistRequestError(
             'Authentication token exchange failed.',
+            err.httpStatusCode,
+            err.responseData,
+        )
+    }
+}
+
+/**
+ * Exchanges a refresh token for a new access token using the OAuth2
+ * `refresh_token` grant.
+ *
+ * @example
+ * ```typescript
+ * const { accessToken, refreshToken } = await refreshAuthToken({
+ *   clientId: 'your-client-id',
+ *   clientSecret: 'your-client-secret',
+ *   refreshToken: storedRefreshToken,
+ * })
+ * ```
+ *
+ * @returns The refreshed token. The response may include a new `refreshToken`
+ * (rotated by the server); persist it in place of the previous one when present.
+ * @throws {@link TodoistRequestError} If the refresh fails
+ */
+export async function refreshAuthToken(
+    args: RefreshTokenRequestArgs,
+    options?: AuthOptions,
+): Promise<AuthTokenResponse> {
+    if (typeof options === 'string') {
+        throw new TypeError(
+            'Passing baseUrl as a string is no longer supported. Use an options object instead: refreshAuthToken(args, { baseUrl })',
+        )
+    }
+    const baseUrl = options?.baseUrl
+    const customFetch = options?.customFetch
+
+    try {
+        const response = await request<AuthTokenResponse>({
+            httpMethod: 'POST',
+            baseUri: getAuthBaseUri(baseUrl),
+            relativePath: ENDPOINT_GET_TOKEN,
+            apiToken: undefined,
+            payload: {
+                clientId: args.clientId,
+                clientSecret: args.clientSecret,
+                refreshToken: args.refreshToken,
+                grantType: 'refresh_token',
+            },
+            customFetch,
+        })
+
+        if (response.status !== 200 || !response.data?.accessToken) {
+            throw new TodoistRequestError(
+                'Authentication token refresh failed.',
+                response.status,
+                response.data,
+            )
+        }
+
+        return response.data
+    } catch (error) {
+        // Re-throw with custom message for authentication failures
+        const err = error as TodoistRequestError
+        throw new TodoistRequestError(
+            'Authentication token refresh failed.',
             err.httpStatusCode,
             err.responseData,
         )

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -113,13 +113,15 @@ export type AuthTokenResponse = {
     /**
      * Refresh token for use with {@link refreshAuthToken}.
      *
-     * Only present when the OAuth app has refresh tokens enabled. New apps have
-     * this on by default; legacy apps must opt in. Apps without it receive a
-     * non-expiring access token and no `refreshToken`/`expiresIn`.
+     * Only present when the OAuth app has refresh tokens enabled — the default
+     * for new apps, and immutable once on. Apps without it receive a long-lived
+     * access token and no refresh token.
      */
     refreshToken?: string
-    /** Access token lifetime in seconds. Present only when the app issues refresh tokens. */
+    /** Access token lifetime in seconds. */
     expiresIn?: number
+    /** Space-separated granted scopes, when returned. */
+    scope?: string
 }
 
 /**
@@ -128,7 +130,11 @@ export type AuthTokenResponse = {
  */
 export type RefreshTokenRequestArgs = {
     clientId: string
-    clientSecret: string
+    /**
+     * Client secret. Required for confidential clients; omit for public clients
+     * registered with `tokenEndpointAuthMethod: 'none'`.
+     */
+    clientSecret?: string
     refreshToken: string
 }
 
@@ -252,6 +258,38 @@ export function getAuthorizationUrl({
  * @returns The access token response
  * @throws {@link TodoistRequestError} If the token exchange fails
  */
+/**
+ * Posts a payload to the OAuth token endpoint and returns the token response,
+ * mapping any failure to a {@link TodoistRequestError} with `errorMessage`.
+ * Shared by {@link getAuthToken} and {@link refreshAuthToken}.
+ */
+async function requestAuthToken(
+    payload: Record<string, unknown>,
+    errorMessage: string,
+    options?: AuthOptions,
+): Promise<AuthTokenResponse> {
+    try {
+        const response = await request<AuthTokenResponse>({
+            httpMethod: 'POST',
+            baseUri: getAuthBaseUri(options?.baseUrl),
+            relativePath: ENDPOINT_GET_TOKEN,
+            apiToken: undefined,
+            payload,
+            customFetch: options?.customFetch,
+        })
+
+        if (response.status !== 200 || !response.data?.accessToken) {
+            throw new TodoistRequestError(errorMessage, response.status, response.data)
+        }
+
+        return response.data
+    } catch (error) {
+        // Re-throw with custom message for authentication failures
+        const err = error as TodoistRequestError
+        throw new TodoistRequestError(errorMessage, err.httpStatusCode, err.responseData)
+    }
+}
+
 export async function getAuthToken(
     args: AuthTokenRequestArgs,
     options?: AuthOptions,
@@ -261,47 +299,21 @@ export async function getAuthToken(
             'Passing baseUrl as a string is no longer supported. Use an options object instead: getAuthToken(args, { baseUrl })',
         )
     }
-    const baseUrl = options?.baseUrl
-    const customFetch = options?.customFetch
 
-    try {
-        const response = await request<AuthTokenResponse>({
-            httpMethod: 'POST',
-            baseUri: getAuthBaseUri(baseUrl),
-            relativePath: ENDPOINT_GET_TOKEN,
-            apiToken: undefined,
-            payload: args,
-            customFetch,
-        })
-
-        if (response.status !== 200 || !response.data?.accessToken) {
-            throw new TodoistRequestError(
-                'Authentication token exchange failed.',
-                response.status,
-                response.data,
-            )
-        }
-
-        return response.data
-    } catch (error) {
-        // Re-throw with custom message for authentication failures
-        const err = error as TodoistRequestError
-        throw new TodoistRequestError(
-            'Authentication token exchange failed.',
-            err.httpStatusCode,
-            err.responseData,
-        )
-    }
+    return requestAuthToken({ ...args }, 'Authentication token exchange failed.', options)
 }
 
 /**
  * Exchanges a refresh token for a new access token using the OAuth2
  * `refresh_token` grant.
  *
- * Only relevant for OAuth apps that have refresh tokens enabled (default for
- * new apps; legacy apps must opt in). Apps without refresh tokens never receive
- * a `refreshToken` from {@link getAuthToken}, so they have nothing to pass here —
- * their access tokens do not expire.
+ * Only relevant for OAuth apps that have refresh tokens enabled (the default for
+ * new apps). Apps without them never receive a `refreshToken` from
+ * {@link getAuthToken}, so they have nothing to pass here — their access tokens
+ * are long-lived instead.
+ *
+ * Omit `clientSecret` for public clients registered with
+ * `tokenEndpointAuthMethod: 'none'`.
  *
  * @example
  * ```typescript
@@ -312,55 +324,24 @@ export async function getAuthToken(
  * })
  * ```
  *
- * @returns The refreshed token. The response may include a new `refreshToken`
- * (rotated by the server); persist it in place of the previous one when present.
+ * @returns The refreshed token. The server rotates the refresh token, so the
+ * response carries a new `refreshToken` — persist it in place of the old one.
  * @throws {@link TodoistRequestError} If the refresh fails
  */
 export async function refreshAuthToken(
     args: RefreshTokenRequestArgs,
     options?: AuthOptions,
 ): Promise<AuthTokenResponse> {
-    if (typeof options === 'string') {
-        throw new TypeError(
-            'Passing baseUrl as a string is no longer supported. Use an options object instead: refreshAuthToken(args, { baseUrl })',
-        )
+    const payload: Record<string, unknown> = {
+        clientId: args.clientId,
+        refreshToken: args.refreshToken,
+        grantType: 'refresh_token',
     }
-    const baseUrl = options?.baseUrl
-    const customFetch = options?.customFetch
-
-    try {
-        const response = await request<AuthTokenResponse>({
-            httpMethod: 'POST',
-            baseUri: getAuthBaseUri(baseUrl),
-            relativePath: ENDPOINT_GET_TOKEN,
-            apiToken: undefined,
-            payload: {
-                clientId: args.clientId,
-                clientSecret: args.clientSecret,
-                refreshToken: args.refreshToken,
-                grantType: 'refresh_token',
-            },
-            customFetch,
-        })
-
-        if (response.status !== 200 || !response.data?.accessToken) {
-            throw new TodoistRequestError(
-                'Authentication token refresh failed.',
-                response.status,
-                response.data,
-            )
-        }
-
-        return response.data
-    } catch (error) {
-        // Re-throw with custom message for authentication failures
-        const err = error as TodoistRequestError
-        throw new TodoistRequestError(
-            'Authentication token refresh failed.',
-            err.httpStatusCode,
-            err.responseData,
-        )
+    if (args.clientSecret !== undefined) {
+        payload.clientSecret = args.clientSecret
     }
+
+    return requestAuthToken(payload, 'Authentication token refresh failed.', options)
 }
 
 /**

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -110,9 +110,15 @@ export type AuthTokenRequestArgs = {
 export type AuthTokenResponse = {
     accessToken: string
     tokenType: string
-    /** Refresh token, when the authorization server issues one. */
+    /**
+     * Refresh token for use with {@link refreshAuthToken}.
+     *
+     * Only present when the OAuth app has refresh tokens enabled. New apps have
+     * this on by default; legacy apps must opt in. Apps without it receive a
+     * non-expiring access token and no `refreshToken`/`expiresIn`.
+     */
     refreshToken?: string
-    /** Access token lifetime in seconds, when provided. */
+    /** Access token lifetime in seconds. Present only when the app issues refresh tokens. */
     expiresIn?: number
 }
 
@@ -291,6 +297,11 @@ export async function getAuthToken(
 /**
  * Exchanges a refresh token for a new access token using the OAuth2
  * `refresh_token` grant.
+ *
+ * Only relevant for OAuth apps that have refresh tokens enabled (default for
+ * new apps; legacy apps must opt in). Apps without refresh tokens never receive
+ * a `refreshToken` from {@link getAuthToken}, so they have nothing to pass here —
+ * their access tokens do not expire.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## What

Adds a `refreshAuthToken` helper so consumers can refresh an expired OAuth access token using the refresh token, without sending the user back through the authorization flow.

Previously `getAuthToken` returned only `{ accessToken, tokenType }` and there was no refresh path — applications had to hand-roll the `refresh_token` grant.

## Changes

- `refreshAuthToken(args, options?)` in `src/authentication.ts` — POSTs to the existing token endpoint (`getAuthBaseUri` + `ENDPOINT_GET_TOKEN`, i.e. `todoist.com/oauth/access_token`) with `grant_type: 'refresh_token'`. Mirrors `getAuthToken`'s structure, `baseUrl`-string guard, and error handling. Throws `TodoistRequestError` with `'Authentication token refresh failed.'` on failure.
- New `RefreshTokenRequestArgs` type (`clientId`, `clientSecret`, `refreshToken`).
- `AuthTokenResponse` extended with optional `refreshToken` and `expiresIn`.
- Tests: happy path (asserts the snake_cased request body and full response), custom `baseUrl`, and non-200 failure.
- README: refresh example added to the OAuth section.

Exported automatically via `export * from './authentication'`.

## Caveat: refresh tokens are opt-in per app

Not all OAuth apps issue refresh tokens. It's on by default for new apps; legacy apps must opt in. Apps without it receive a non-expiring access token and **no** `refreshToken`/`expiresIn` in the exchange response — so there's nothing to refresh. The response fields are typed optional (`?`) to model this, and the caveat is documented on `AuthTokenResponse`, `refreshAuthToken`, and in the README so callers know absence is expected, not an error.

## Verification

- `npm test` — 629 passing
- `npm run check` (oxlint + oxfmt) — clean
- `npm run ts-compile-check` — no new errors (the 4 reported are pre-existing on `main`, in `apps`/`app-installations`/`ui-extensions` test files I didn't touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)