### PR TITLE
fix: use undici's own fetch to avoid version mismatch on Node 26

### DIFF
--- a/src/test-utils/transport-seam.ts
+++ b/src/test-utils/transport-seam.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest'
+
+// In production the transport uses undici's own `fetch` (paired with the
+// dispatcher) so the request client and dispatcher stay on one undici version.
+// MSW intercepts the *global* `fetch`, not that separate undici instance, so
+// force the transport onto the global `fetch` for every test in the suite; MSW
+// then intercepts requests as usual. The real undici transport is covered
+// directly by `http-dispatcher.test.ts` and `fetch-with-retry.test.ts`, which
+// opt out of this seam with `vi.unmock('./http-dispatcher')`.
+//
+// This lives in its own setup file (not `msw-setup.ts`) because a hoisted
+// `vi.mock` in a module that also re-exports values corrupts those exports.
+vi.mock('../transport/http-dispatcher', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../transport/http-dispatcher')>()
+    return {
+        ...actual,
+        getDefaultTransport: vi.fn(async () => undefined),
+    }
+})

--- a/src/transport/fetch-with-retry.test.ts
+++ b/src/transport/fetch-with-retry.test.ts
@@ -1,7 +1,18 @@
+import type { Dispatcher } from 'undici'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { CustomFetch, CustomFetchResponse } from '../types/http'
 import { fetchWithRetry } from './fetch-with-retry'
 import * as httpDispatcher from './http-dispatcher'
+
+// This file controls the transport directly, so opt out of the suite-wide
+// seam installed in `test-utils/msw-setup.ts`.
+vi.unmock('./http-dispatcher')
+
+// A minimal dispatcher for tests that exercise the built-in fetch path with a
+// dispatcher present but no paired undici fetch (so the global fetch is used).
+function fakeDispatcher(): Dispatcher {
+    return { dispatch() {}, close: async () => {} } as unknown as Dispatcher
+}
 
 describe('fetchWithRetry', () => {
     const originalFetch = global.fetch
@@ -25,11 +36,16 @@ describe('fetchWithRetry', () => {
         )
         global.fetch = fetchMock
 
+        const dispatcher = fakeDispatcher()
+        vi.spyOn(httpDispatcher, 'getDefaultTransport').mockResolvedValue({
+            dispatcher,
+            fetch: undefined,
+        })
+
         const response = await fetchWithRetry<{ ok: boolean }>({
             url: 'https://api.todoist.com/api/v1/tasks',
             options: { method: 'GET' },
         })
-        const dispatcher = await httpDispatcher.getDefaultDispatcher()
 
         expect(fetchMock).toHaveBeenCalledTimes(1)
         expect(fetchMock).toHaveBeenCalledWith(
@@ -42,11 +58,42 @@ describe('fetchWithRetry', () => {
         expect(response.data).toEqual({ ok: true })
     })
 
+    test('prefers undici’s paired fetch over the global fetch', async () => {
+        const globalFetchMock = vi.fn<typeof fetch>()
+        global.fetch = globalFetchMock
+
+        const nodeFetch = vi.fn<typeof fetch>()
+        nodeFetch.mockResolvedValue(
+            new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+            }),
+        )
+        const dispatcher = fakeDispatcher()
+        vi.spyOn(httpDispatcher, 'getDefaultTransport').mockResolvedValue({
+            dispatcher,
+            fetch: nodeFetch as unknown as typeof import('undici').fetch,
+        })
+
+        const response = await fetchWithRetry<{ ok: boolean }>({
+            url: 'https://api.todoist.com/api/v1/tasks',
+            options: { method: 'GET' },
+        })
+
+        expect(nodeFetch).toHaveBeenCalledWith(
+            'https://api.todoist.com/api/v1/tasks',
+            expect.objectContaining({ method: 'GET', dispatcher }),
+        )
+        expect(globalFetchMock).not.toHaveBeenCalled()
+        expect(response.data).toEqual({ ok: true })
+    })
+
     test('prefers customFetch over the built-in fetch path', async () => {
         const fetchMock = vi.fn<typeof fetch>()
         global.fetch = fetchMock
 
-        const getDefaultDispatcherSpy = vi.spyOn(httpDispatcher, 'getDefaultDispatcher')
+        const getDefaultTransportSpy = vi.spyOn(httpDispatcher, 'getDefaultTransport')
         const customFetch = vi.fn<CustomFetch>()
         customFetch.mockResolvedValue(createResponse('{"ok":true}'))
 
@@ -60,7 +107,7 @@ describe('fetchWithRetry', () => {
             customFetch,
         })
 
-        expect(getDefaultDispatcherSpy).not.toHaveBeenCalled()
+        expect(getDefaultTransportSpy).not.toHaveBeenCalled()
         expect(customFetch).toHaveBeenCalledTimes(1)
         expect(customFetch).toHaveBeenCalledWith(
             'https://api.todoist.com/api/v1/tasks',
@@ -124,6 +171,11 @@ describe('fetchWithRetry', () => {
             )
         global.fetch = fetchMock
 
+        vi.spyOn(httpDispatcher, 'getDefaultTransport').mockResolvedValue({
+            dispatcher: fakeDispatcher(),
+            fetch: undefined,
+        })
+
         const requestPromise = fetchWithRetry<{ ok: boolean }>({
             url: 'https://api.todoist.com/api/v1/tasks',
             options: { method: 'GET', timeout: 20 },
@@ -164,7 +216,10 @@ describe('fetchWithRetry', () => {
         )
         global.fetch = fetchMock
 
-        const getDefaultDispatcherSpy = vi.spyOn(httpDispatcher, 'getDefaultDispatcher')
+        const dispatcher = fakeDispatcher()
+        const getDefaultTransportSpy = vi
+            .spyOn(httpDispatcher, 'getDefaultTransport')
+            .mockResolvedValue({ dispatcher, fetch: undefined })
 
         const requestPromise = fetchWithRetry({
             url: 'https://api.todoist.com/api/v1/tasks',
@@ -179,11 +234,11 @@ describe('fetchWithRetry', () => {
 
         await requestExpectation
 
-        expect(getDefaultDispatcherSpy).toHaveBeenCalled()
+        expect(getDefaultTransportSpy).toHaveBeenCalled()
         expect(fetchMock).toHaveBeenCalledWith(
             'https://api.todoist.com/api/v1/tasks',
             expect.objectContaining({
-                dispatcher: expect.anything(),
+                dispatcher,
                 signal: expect.any(AbortSignal),
             }),
         )

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -1,6 +1,6 @@
 import type { CustomFetch, CustomFetchResponse, HttpResponse, RetryConfig } from '../types/http'
 import { isNetworkError } from '../types/http'
-import { getDefaultDispatcher } from './http-dispatcher'
+import { getDefaultTransport } from './http-dispatcher'
 
 /**
  * Default retry configuration matching the original axios-retry behavior
@@ -138,18 +138,29 @@ export async function fetchWithRetry<T = unknown>(args: {
                     timeout,
                 })
             } else {
-                const dispatcher = await getDefaultDispatcher()
+                // Read the dispatcher and its paired `fetch` as one value so
+                // they can never be mismatched. On Node, `fetch` is undici's
+                // own — paired with the dispatcher — so the request client and
+                // dispatcher stay on one undici version; otherwise the
+                // `decompress` interceptor terminates gzip responses when the
+                // global `fetch`'s bundled undici differs. Browser/edge (and
+                // Bun) have no paired `fetch` and fall back to the global one.
+                const transport = await getDefaultTransport()
                 const nativeFetchOptions = {
                     ...fetchOptions,
                     signal: requestSignal,
                 }
 
-                if (dispatcher !== undefined) {
+                if (transport?.dispatcher !== undefined) {
                     // @ts-expect-error - dispatcher is a valid option for Node.js fetch but not in the TS types
-                    nativeFetchOptions.dispatcher = dispatcher
+                    nativeFetchOptions.dispatcher = transport.dispatcher
                 }
 
-                const nativeResponse = await fetch(url, nativeFetchOptions)
+                // undici's `fetch` and the global `fetch` are the same function
+                // at runtime but carry different (undici vs DOM) types. Call
+                // through the global signature, which matches the options above.
+                const fetchImpl = (transport?.fetch ?? fetch) as typeof fetch
+                const nativeResponse = await fetchImpl(url, nativeFetchOptions)
                 fetchResponse = convertResponseToCustomFetch(nativeResponse)
             }
 

--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -2,12 +2,19 @@ import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { gzipSync } from 'node:zlib'
 import { http, passthrough } from 'msw'
+import { fetch as undiciFetch } from 'undici'
 import { server } from '../test-utils/msw-setup'
 import {
     getDefaultDispatcher,
+    getDefaultFetch,
     resetDefaultDispatcherForTests,
     suppressExperimentalWarningsSync,
 } from './http-dispatcher'
+
+// This file exercises the real dispatcher, so opt out of the suite-wide
+// transport seam installed in `test-utils/msw-setup.ts`. `vi.unmock` is hoisted
+// above the imports above, so the real module is loaded here.
+vi.unmock('./http-dispatcher')
 
 describe('http-dispatcher', () => {
     afterEach(async () => {
@@ -19,6 +26,14 @@ describe('http-dispatcher', () => {
 
         expect(dispatcher).toBeDefined()
         expect(typeof dispatcher?.dispatch).toBe('function')
+    })
+
+    test('pairs the dispatcher with undici’s own fetch in Node', async () => {
+        await getDefaultDispatcher()
+
+        // The bridge that fixes the version mismatch: the resolved transport
+        // must carry undici's own `fetch`, not the global one.
+        expect(getDefaultFetch()).toBe(undiciFetch)
     })
 
     test('caches the dispatcher instance', async () => {
@@ -88,6 +103,7 @@ describe('http-dispatcher', () => {
                 async close() {}
             },
             interceptors: {},
+            fetch: vi.fn(),
         }))
 
         try {

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -1,5 +1,8 @@
 import type { Dispatcher } from 'undici'
 
+// undici's own `fetch`, typed from the same package the dispatcher comes from.
+type UndiciFetch = typeof import('undici').fetch
+
 // Use effectively-disabled keep-alive so short-lived CLI processes do not stay
 // open waiting on idle sockets. Undici requires positive values, so we use 1ms.
 const KEEP_ALIVE_OPTIONS = {
@@ -7,42 +10,88 @@ const KEEP_ALIVE_OPTIONS = {
     keepAliveMaxTimeout: 1,
 }
 
-let defaultDispatcherPromise: Promise<Dispatcher> | undefined
+/**
+ * A dispatcher and the `fetch` that must be used with it. `fetch` is undici's
+ * own `fetch` on the full-undici Node path, or `undefined` (meaning: use the
+ * global `fetch`) on the Bun path. The two are cached together so callers can
+ * never observe a dispatcher paired with a mismatched `fetch` — see
+ * {@link getDefaultFetch} for why the pairing matters.
+ */
+type DefaultTransport = { dispatcher: Dispatcher; fetch: UndiciFetch | undefined }
 
-export function getDefaultDispatcher(): Promise<Dispatcher | undefined> {
+let defaultTransport: DefaultTransport | undefined
+let defaultTransportPromise: Promise<DefaultTransport> | undefined
+
+/**
+ * The default dispatcher and its paired `fetch`, as a single value so the two
+ * are always read consistently. Resolves to `undefined` outside Node (browser/
+ * edge), where callers use the global `fetch` with no dispatcher.
+ */
+export function getDefaultTransport(): Promise<DefaultTransport | undefined> {
     if (!isNodeEnvironment()) {
         return Promise.resolve(undefined)
     }
 
-    if (!defaultDispatcherPromise) {
-        defaultDispatcherPromise = createDefaultDispatcher().catch((error) => {
-            defaultDispatcherPromise = undefined
-            throw error
-        })
+    if (!defaultTransportPromise) {
+        defaultTransportPromise = createDefaultTransport()
+            .then((transport) => {
+                defaultTransport = transport
+                return transport
+            })
+            .catch((error) => {
+                defaultTransport = undefined
+                defaultTransportPromise = undefined
+                throw error
+            })
     }
 
-    return defaultDispatcherPromise
+    return defaultTransportPromise
+}
+
+export async function getDefaultDispatcher(): Promise<Dispatcher | undefined> {
+    return (await getDefaultTransport())?.dispatcher
+}
+
+/**
+ * The `fetch` implementation that must be used with the default dispatcher.
+ * Returns undici's own `fetch` on the full-undici Node path, or `undefined`
+ * (meaning: use the global `fetch`) in the browser/edge/Bun paths.
+ *
+ * Node's global `fetch` is backed by whatever undici version ships inside that
+ * Node release (6.x on Node 22 … 8.x on Node 26). Our dispatcher — and its
+ * `decompress` interceptor — comes from the npm `undici` package, which is a
+ * different version. Handing an npm-undici dispatcher to a mismatched built-in
+ * client makes gzip responses fail mid-stream with `terminated`. Sourcing
+ * `fetch` from the same npm `undici` keeps the whole request path on one
+ * version and removes the split.
+ *
+ * Only meaningful after {@link getDefaultTransport} has resolved, which is the
+ * one place that populates it.
+ */
+export function getDefaultFetch(): UndiciFetch | undefined {
+    return defaultTransport?.fetch
 }
 
 export async function resetDefaultDispatcherForTests(): Promise<void> {
-    if (!defaultDispatcherPromise) {
+    if (!defaultTransportPromise) {
         return
     }
 
-    const dispatcherPromise = defaultDispatcherPromise
-    defaultDispatcherPromise = undefined
+    const transportPromise = defaultTransportPromise
+    defaultTransport = undefined
+    defaultTransportPromise = undefined
 
-    await dispatcherPromise.then(
-        (dispatcher) => dispatcher.close(),
+    await transportPromise.then(
+        (transport) => transport.dispatcher.close(),
         () => undefined,
     )
 }
 
-async function createDefaultDispatcher(): Promise<Dispatcher> {
+async function createDefaultTransport(): Promise<DefaultTransport> {
     // Dynamic import so non-Node consumers (browser, edge runtimes) don't pull
-    // undici into their bundle. `getDefaultDispatcher` already short-circuits
+    // undici into their bundle. `getDefaultTransport` already short-circuits
     // outside Node, so this branch only runs when undici is safe to load.
-    const { EnvHttpProxyAgent, interceptors } = await import('undici')
+    const { EnvHttpProxyAgent, interceptors, fetch: undiciFetch } = await import('undici')
 
     const agent = new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
 
@@ -53,7 +102,9 @@ async function createDefaultDispatcher(): Promise<Dispatcher> {
     // gzip/deflate/br/zstd natively — so skip the interceptor instead of
     // crashing on the missing API.
     if (typeof interceptors.decompress !== 'function') {
-        return agent
+        // Bun: pair the agent with the global `fetch` (undefined), which
+        // decompresses natively.
+        return { dispatcher: agent, fetch: undefined }
     }
 
     // Compose the response-decompression interceptor so gzip/deflate/br/zstd
@@ -64,7 +115,12 @@ async function createDefaultDispatcher(): Promise<Dispatcher> {
     // See https://github.com/Doist/todoist-cli/issues/318.
     const decompress = suppressExperimentalWarningsSync(() => interceptors.decompress())
 
-    return agent.compose(decompress)
+    // Pair undici's own `fetch` with this dispatcher so the request client and
+    // the dispatcher stay on one undici version (see `getDefaultFetch`). The
+    // global `fetch` is backed by a different, Node-bundled undici; mixing the
+    // two makes the decompress interceptor terminate gzip responses on some
+    // Node versions.
+    return { dispatcher: agent.compose(decompress), fetch: undiciFetch }
 }
 
 // undici emits an `ExperimentalWarning` the first time `interceptors.decompress()`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['**/*.test.ts'],
-        setupFiles: ['./src/test-utils/msw-setup.ts'],
+        setupFiles: ['./src/test-utils/transport-seam.ts', './src/test-utils/msw-setup.ts'],
         clearMocks: true,
         coverage: {
             provider: 'v8',


### PR DESCRIPTION
Ports the comms-sdk transport fix ([Doist/comms-sdk-typescript#44](https://github.com/Doist/comms-sdk-typescript/pull/44)) to todoist-sdk.

## Problem

The transport builds its dispatcher (`EnvHttpProxyAgent` + `interceptors.decompress()`) from the npm `undici` package, then hands it to Node's **global** `fetch`, which is backed by whatever undici ships inside the Node release (6.x on Node 22 … 8.x on Node 26). Driving a v7 dispatcher/interceptor with a v8 `fetch` core makes the decompress interceptor terminate gzip responses mid-stream with `terminated`.

The Todoist API happens to stream responses `Transfer-Encoding: chunked`, which the mismatched interceptor tolerates today — so `td` works on Node 26 by luck. A `Content-Length` gzip endpoint (as Comms uses) would break identically. This aligns the SDK with the fixed behaviour and future-proofs it.

## Fix

- Source `fetch` from the same `import('undici')` that builds the dispatcher and use it on the Node path, so the request client and dispatcher stay on one undici version.
- Cache the dispatcher and its paired `fetch` together as a single `DefaultTransport`, read via `getDefaultTransport()`, so they can never be observed mismatched.
- Fall back to the global `fetch` in the browser/edge (and Bun) path.
- Server-side gzip is kept — no bandwidth regression.

## Tests

MSW intercepts the global `fetch`, not the separate undici instance, so a suite-wide seam (in its own `test-utils/transport-seam.ts` setup file) routes MSW tests through the global `fetch`; the transport tests opt out and exercise the real undici path. Added coverage that the dispatcher is paired with undici's own `fetch`, plus a test that the paired fetch is preferred.

## Verified

- Full suite: 643/643 pass; `tsc` + oxlint + oxfmt clean.
- Built against this branch and ran the Todoist CLI `doctor` + `project list` on Node **22** and **26**: both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)