### PR TITLE
fix(workspaces)!: remove invitation `isExistingUser`

### DIFF
--- a/src/todoist-api.workspaces.test.ts
+++ b/src/todoist-api.workspaces.test.ts
@@ -102,7 +102,6 @@ describe('TodoistApi workspaces', () => {
                     userEmail: 'admin@example.com',
                     workspaceId: '456',
                     role: 'ADMIN' as const,
-                    isExistingUser: true,
                 },
             ]
             server.use(
@@ -137,7 +136,6 @@ describe('TodoistApi workspaces', () => {
             userEmail: 'user@example.com',
             workspaceId: '789',
             role: 'MEMBER' as const,
-            isExistingUser: false,
         }
 
         test('deletes workspace invitation', async () => {
@@ -163,7 +161,6 @@ describe('TodoistApi workspaces', () => {
             userEmail: 'user@example.com',
             workspaceId: '789',
             role: 'GUEST' as const,
-            isExistingUser: true,
         }
 
         test('accepts workspace invitation', async () => {
@@ -186,7 +183,6 @@ describe('TodoistApi workspaces', () => {
             userEmail: 'user@example.com',
             workspaceId: '789',
             role: 'ADMIN' as const,
-            isExistingUser: false,
         }
 
         test('rejects workspace invitation', async () => {

--- a/src/types/workspaces/types.ts
+++ b/src/types/workspaces/types.ts
@@ -47,7 +47,6 @@ export const WorkspaceInvitationSchema = z.object({
     userEmail: z.string(),
     workspaceId: z.string(),
     role: WorkspaceRoleSchema,
-    isExistingUser: z.boolean(),
 })
 
 /**


### PR DESCRIPTION
## Overview

An upcoming backend API change stops returning `is_existing_user` on workspace invitation responses. This PR removes it from the SDK, and needs to be released before that change lands.

All four methods share the schema, so all four are affected:

- `getAllWorkspaceInvitations`
- `deleteWorkspaceInvitation`
- `acceptWorkspaceInvitation`
- `rejectWorkspaceInvitation`


## Breaking change

`WorkspaceInvitation` no longer has an `isExistingUser` field.
