### PR TITLE
fix: normalize full project collaborators

### DIFF
--- a/src/clients/project-client.ts
+++ b/src/clients/project-client.ts
@@ -46,6 +46,7 @@ import {
     validateProjectArray,
     validateSectionArray,
     validateTaskArray,
+    validateUser,
     validateUserArray,
     validateWorkspaceProject,
     validateWorkspaceProjectArray,
@@ -288,8 +289,14 @@ export class ProjectClient extends BaseClient {
             commentsCount: data.commentsCount as number,
             tasks: validateTaskArray(data.tasks as unknown[]),
             sections: validateSectionArray(data.sections as unknown[]),
-            collaborators: validateUserArray(data.collaborators as unknown[]),
-            notes: validateCommentArray(data.notes as unknown[]),
+            collaborators: validateCollaboratorArray(data.collaborators).map((collaborator) =>
+                validateUser({
+                    id: collaborator.id,
+                    email: collaborator.email,
+                    name: collaborator.fullName,
+                }),
+            ),
+            notes: validateCommentArray(data.notes ?? []),
         }
     }
 

--- a/src/clients/project-client.ts
+++ b/src/clients/project-client.ts
@@ -296,7 +296,7 @@ export class ProjectClient extends BaseClient {
                     name: collaborator.fullName,
                 }),
             ),
-            notes: validateCommentArray(data.notes ?? []),
+            notes: validateCommentArray(data.notes === undefined ? [] : data.notes),
         }
     }
 

--- a/src/todoist-api.projects.test.ts
+++ b/src/todoist-api.projects.test.ts
@@ -22,7 +22,6 @@ import {
     DEFAULT_PROJECT_ID,
     DEFAULT_TASK,
     DEFAULT_SECTION,
-    DEFAULT_RAW_COMMENT,
     DEFAULT_FOLDER,
     DEFAULT_COLLABORATOR,
     DEFAULT_COLLABORATOR_STATE,
@@ -388,33 +387,51 @@ describe('TodoistApi project endpoints', () => {
     })
 
     describe('getFullProject', () => {
+        const fullProjectUrl = `${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}/123/${ENDPOINT_REST_PROJECT_FULL}`
+        const rawCollaborator = {
+            id: DEFAULT_COLLABORATOR.id,
+            email: DEFAULT_COLLABORATOR.email,
+            full_name: DEFAULT_COLLABORATOR.fullName,
+            timezone: DEFAULT_COLLABORATOR.timezone,
+            image_id: DEFAULT_COLLABORATOR.imageId,
+        }
+        const baseFullData = {
+            project: null,
+            comments_count: 0,
+            tasks: [],
+            sections: [],
+        }
+
+        function respondWith(data: Record<string, unknown>) {
+            server.use(http.get(fullProjectUrl, () => HttpResponse.json(data, { status: 200 })))
+        }
+
         test('returns full project data from rest client', async () => {
-            const fullData = {
+            respondWith({
                 project: DEFAULT_PROJECT,
-                commentsCount: 5,
+                comments_count: 5,
                 tasks: [DEFAULT_TASK],
                 sections: [DEFAULT_SECTION],
-                collaborators: [DEFAULT_USER],
-                notes: [DEFAULT_RAW_COMMENT],
-            }
-            server.use(
-                http.get(
-                    `${getSyncBaseUri()}${ENDPOINT_REST_PROJECTS}/123/${ENDPOINT_REST_PROJECT_FULL}`,
-                    () => {
-                        return HttpResponse.json(fullData, { status: 200 })
-                    },
-                ),
-            )
+                collaborators: [rawCollaborator],
+            })
             const api = getTarget()
 
             const result = await api.getFullProject('123')
 
             expect(result.project).toEqual(DEFAULT_PROJECT)
             expect(result.commentsCount).toBe(5)
-            expect(result.tasks).toHaveLength(1)
-            expect(result.sections).toHaveLength(1)
-            expect(result.collaborators).toHaveLength(1)
-            expect(result.notes).toHaveLength(1)
+            expect(result.tasks).toEqual([DEFAULT_TASK])
+            expect(result.sections).toEqual([DEFAULT_SECTION])
+            expect(result.collaborators).toEqual([DEFAULT_USER])
+            expect(result.notes).toEqual([])
+        })
+
+        test('rejects a raw collaborator missing full_name', async () => {
+            const collaborator = { ...rawCollaborator, full_name: undefined }
+            respondWith({ ...baseFullData, collaborators: [collaborator], notes: [] })
+            const api = getTarget()
+
+            await expect(api.getFullProject('123')).rejects.toThrow()
         })
     })
 

--- a/src/todoist-api.projects.test.ts
+++ b/src/todoist-api.projects.test.ts
@@ -426,6 +426,13 @@ describe('TodoistApi project endpoints', () => {
             expect(result.notes).toEqual([])
         })
 
+        test('rejects null notes', async () => {
+            respondWith({ ...baseFullData, collaborators: [], notes: null })
+            const api = getTarget()
+
+            await expect(api.getFullProject('123')).rejects.toThrow()
+        })
+
         test('rejects a raw collaborator missing full_name', async () => {
             const collaborator = { ...rawCollaborator, full_name: undefined }
             respondWith({ ...baseFullData, collaborators: [collaborator], notes: [] })


### PR DESCRIPTION
## Summary

- validate `/projects/{id}/full` collaborators using the Sync collaborator schema
- map validated collaborators back to the existing public `User` shape
- treat an omitted `notes` field as an empty array

This keeps `GetFullProjectResponse` backward-compatible while matching the function's current response shape.

## Test plan

Tested locally, this fixes a bug I bumped into using `td`.